### PR TITLE
FATAL_ERROR if no NAME is provided

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -264,6 +264,13 @@ function(CPMAddPackage)
 
   cmake_parse_arguments(CPM_ARGS "" "${oneValueArgs}" "${multiValueArgs}" "${ARGN}")
 
+  # Check for required arguments
+
+  if(NOT DEFINED CPM_ARGS_NAME)
+    message(FATAL_ERROR
+      "CPM: 'NAME' was not provided for package added with arguments: '${ARGN}'")
+  endif()
+
   # Set default values for arguments
 
   if(NOT DEFINED CPM_ARGS_VERSION)

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -267,8 +267,7 @@ function(CPMAddPackage)
   # Check for required arguments
 
   if(NOT DEFINED CPM_ARGS_NAME)
-    message(FATAL_ERROR
-      "CPM: 'NAME' was not provided for package added with arguments: '${ARGN}'")
+    message(FATAL_ERROR "CPM: 'NAME' was not provided for package added with arguments: '${ARGN}'")
   endif()
 
   # Set default values for arguments


### PR DESCRIPTION
Currently if one forgets to provide a name to `CPMAddPackage` (or has a typo like `NSME`) the error they get is relatively obscure from within `cpm_check_if_package_already_added`. This PR adds a clearer error message