### PR TITLE
Improved regex match in cpm_package_name_from_git_uri

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -136,8 +136,7 @@ include(CMakeParseArguments)
 
 # Infer package name from git repository uri (path or url)
 function(cpm_package_name_from_git_uri URI RESULT)
-  string(REGEX MATCH "([^/:]+)/?.git/?$" cpmGitUriMatch "${URI}")
-  if(DEFINED cpmGitUriMatch)
+  if("${URI}" MATCHES "([^/:]+)/?.git/?$")
     set(${RESULT}
         ${CMAKE_MATCH_1}
         PARENT_SCOPE


### PR DESCRIPTION
The old code has an issue (though not a bug). 

Apparently `cpmGitUriMatch` always gets defined, so we never end up in the `else`. However setting a variable to an empty value (`CMAKE_MATCH_1`) is equivalent to unset and that's why the tests pass and there is no bug.

The new code is cleaner and doesn't rely on an unused temporary.