### PR TITLE
Update examples to use shorthand syntax where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ On the other hand, if `VERSION` hasn't been explicitly specified, CPM can automa
 `GIT_TAG` can also be set to a specific commit or a branch name such as `master` to always download the most recent version.
 The optional argument `FIND_PACKAGE_ARGUMENTS` can be specified to a string of parameters that will be passed to `find_package` if enabled (see below).
 
+If an additional optional parameter `EXCLUDE_FROM_ALL` is set to a truthy value, then any targets defined inside the dependency won't be built by default. See the [CMake docs](https://cmake.org/cmake/help/latest/prop_tgt/EXCLUDE_FROM_ALL.html) for details.
+
 A single-argument compact syntax is also supported:
 
 ```cmake
@@ -58,7 +60,7 @@ CPMAddPackage("uri#tag")
 CPMAddPackage("uri@version#tag")
 ```
 
-In the shorthand syntax if the URI is of the form `gh:user/name`, it is interpreted as GitHub URI and converted to `https://github.com/user/name.git`. If the URI is of the form `gl:user/name`, it is interpreted as a [GitLab](https://gitlab.com/explore/) URI and coverted to `https://gitlab.com/user/name.git`. Otherwise the URI used verbatim as a git URL.
+In the shorthand syntax if the URI is of the form `gh:user/name`, it is interpreted as GitHub URI and converted to `https://github.com/user/name.git`. If the URI is of the form `gl:user/name`, it is interpreted as a [GitLab](https://gitlab.com/explore/) URI and coverted to `https://gitlab.com/user/name.git`. Otherwise the URI used verbatim as a git URL. All packages added using the shorthand syntax will be added using the [EXCLUDE_FROM_ALL](https://cmake.org/cmake/help/latest/prop_tgt/EXCLUDE_FROM_ALL.html) flag.
 
 After calling `CPMAddPackage` or `CPMFindPackage`, the following variables are defined in the local scope, where `<dependency>` is the name of the dependency.
 
@@ -82,8 +84,7 @@ add_executable(tests tests.cpp)
 
 # add dependencies
 include(cmake/CPM.cmake)
-
-CPMAddPackage(gh:catchorg/Catch2@2.5.0)
+CPMAddPackage("gh:catchorg/Catch2@2.5.0")
 
 # link dependencies
 target_link_libraries(tests Catch2)

--- a/examples/benchmark/CMakeLists.txt
+++ b/examples/benchmark/CMakeLists.txt
@@ -6,11 +6,7 @@ project(CPMExampleBenchmark)
 
 include(../../cmake/CPM.cmake)
 
-CPMAddPackage(
-  NAME fibonacci
-  GITLAB_REPOSITORY TheLartians/Fibonacci
-  VERSION 2.0
-)
+CPMAddPackage("gh:TheLartians/Fibonacci@2.0")
 
 CPMAddPackage(
   NAME benchmark

--- a/examples/catch2/CMakeLists.txt
+++ b/examples/catch2/CMakeLists.txt
@@ -6,17 +6,8 @@ project(CPMExampleCatch2)
 
 include(../../cmake/CPM.cmake)
 
-CPMAddPackage(
-  NAME fibonacci
-  GITHUB_REPOSITORY TheLartians/Fibonacci
-  VERSION 2.0
-)
-
-CPMAddPackage(
-  NAME Catch2
-  GITHUB_REPOSITORY catchorg/Catch2
-  VERSION 2.13.4
-)
+CPMAddPackage("gh:TheLartians/Fibonacci@2.0")
+CPMAddPackage("gh:catchorg/Catch2@2.13.4")
 
 # ---- Create binary ----
 

--- a/examples/doctest/CMakeLists.txt
+++ b/examples/doctest/CMakeLists.txt
@@ -6,17 +6,8 @@ project(CPMExampleDoctest)
 
 include(../../cmake/CPM.cmake)
 
-CPMAddPackage(
-  NAME fibonacci
-  GITLAB_REPOSITORY TheLartians/Fibonacci
-  VERSION 2.0
-)
-
-CPMAddPackage(
-  NAME doctest
-  GITHUB_REPOSITORY onqtam/doctest
-  GIT_TAG 2.4.5
-)
+CPMAddPackage("gh:TheLartians/Fibonacci@2.0")
+CPMAddPackage("gh:onqtam/doctest#2.4.5")
 
 # ---- Create binary ----
 

--- a/examples/fmt/CMakeLists.txt
+++ b/examples/fmt/CMakeLists.txt
@@ -6,11 +6,7 @@ project(CPMJSONExample)
 
 include(../../cmake/CPM.cmake)
 
-CPMAddPackage(
-  NAME fmt
-  GIT_TAG 7.1.3
-  GITHUB_REPOSITORY fmtlib/fmt
-)
+CPMAddPackage("gh:fmtlib/fmt#7.1.3")
 
 # ---- Executable ----
 

--- a/examples/gtest/CMakeLists.txt
+++ b/examples/gtest/CMakeLists.txt
@@ -6,11 +6,7 @@ project(CPMExampleGtest)
 
 include(../../cmake/CPM.cmake)
 
-CPMAddPackage(
-  NAME fibonacci
-  GITLAB_REPOSITORY TheLartians/Fibonacci
-  VERSION 2.0
-)
+CPMAddPackage("gh:TheLartians/Fibonacci@2.0")
 
 CPMAddPackage(
   NAME googletest

--- a/examples/linenoise/CMakeLists.txt
+++ b/examples/linenoise/CMakeLists.txt
@@ -6,11 +6,7 @@ project(CPMlinenoiseExample)
 
 include(../../cmake/CPM.cmake)
 
-CPMAddPackage(
-  NAME linenoise
-  GIT_TAG 1.0
-  GITHUB_REPOSITORY antirez/linenoise
-)
+CPMAddPackage("gh:antirez/linenoise#1.0")
 
 if(linenoise_ADDED)
   add_library(linenoise ${linenoise_SOURCE_DIR}/linenoise.c)

--- a/examples/spdlog/CMakeLists.txt
+++ b/examples/spdlog/CMakeLists.txt
@@ -6,11 +6,7 @@ project(CPMSpdlogExample)
 
 include(../../cmake/CPM.cmake)
 
-CPMAddPackage(
-  NAME spdlog
-  GITHUB_REPOSITORY gabime/spdlog
-  VERSION 1.8.2
-)
+CPMAddPackage("gh:gabime/spdlog@1.8.2")
 
 # ---- Executable ----
 


### PR DESCRIPTION
To further propagate the new shorthand syntax for suited CPM.cmake dependencies, this PR updates the examples to use the new Syntax where possible. Also consistently adds quotation marks, potentially avoiding confusion for the `#` syntax, as is would be interpreted as a comment without quotes. Also clarifies the `EXCLUDE_FROM_ALL` behaviour in the readme.