### PR TITLE
update more examples to use shorthand syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,44 +82,6 @@ After calling `CPMAddPackage` or `CPMFindPackage`, the following variables are d
 The difference between `CPMFindPackage` and `CPMAddPackage` is that `CPMFindPackage` will try to find a local dependency via CMake's `find_package` and fallback to `CPMAddPackage` if the dependency is not found.
 This behaviour can be also modified globally via [CPM options](#options).
 
-## Full CMakeLists Example
-
-```cmake
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
-
-# create project
-project(MyProject)
-
-# add executable
-add_executable(tests tests.cpp)
-
-# add dependencies
-include(cmake/CPM.cmake)
-CPMAddPackage("gh:catchorg/Catch2@2.5.0")
-
-# link dependencies
-target_link_libraries(tests Catch2)
-```
-
-See the [examples directory](https://github.com/cpm-cmake/CPM.cmake/tree/master/examples) for complete examples with source code and check [below](#snippets) or in the [wiki](https://github.com/cpm-cmake/CPM.cmake/wiki/More-Snippets) for example snippets.
-
-## Adding CPM
-
-To add CPM to your current project, simply add the [latest release](https://github.com/cpm-cmake/CPM.cmake/releases/latest) of `CPM.cmake` or `get_cpm.cmake` to your project's `cmake` directory.
-The command below will perform this automatically.
-
-```bash
-mkdir -p cmake
-wget -O cmake/CPM.cmake https://github.com/cpm-cmake/CPM.cmake/releases/latest/download/get_cpm.cmake
-```
-
-You can also download CPM.cmake directly from your project's `CMakeLists.txt`. See the [wiki](https://github.com/cpm-cmake/CPM.cmake/wiki/Downloading-CPM.cmake-in-CMake) for more details.
-
-## Updating CPM
-
-To update CPM to the newest version, update the script in the project's root directory, for example by running the command above.
-Dependencies using CPM will automatically use the updated script of the outermost project.
-
 ## Advantages
 
 - **Small and reusable projects** CPM takes care of all project dependencies, allowing developers to focus on creating small, well-tested libraries.
@@ -266,13 +228,13 @@ See the [wiki](https://github.com/cpm-cmake/CPM.cmake/wiki/More-Snippets) for mo
 ### [Catch2](https://github.com/catchorg/Catch2)
 
 ```cmake
-CPMAddPackage(gh:catchorg/Catch2@2.5.0)
+CPMAddPackage("gh:catchorg/Catch2@2.5.0")
 ```
 
 ### [Boost (via boost-cmake)](https://github.com/Orphis/boost-cmake)
 
 ```CMake
-CPMAddPackage(gh:Orphis/boost-cmake@1.67.0)
+CPMAddPackage("gh:Orphis/boost-cmake@1.67.0")
 ```
 
 ### [cxxopts](https://github.com/jarro2783/cxxopts)

--- a/README.md
+++ b/README.md
@@ -290,10 +290,15 @@ CPMAddPackage("gh:jbeder/yaml-cpp#yaml-cpp-0.6.3@0.6.3")
 ### [google/benchmark](https://github.com/google/benchmark)
 
 ```cmake
-CPMAddPackage("gh:google/benchmark@1.5.2")
+CPMAddPackage(
+  NAME benchmark
+  GITHUB_REPOSITORY google/benchmark
+  VERSION 1.5.2
+  OPTIONS "BENCHMARK_ENABLE_TESTING Off"
+)
 
-if (benchmark_ADDED)
-  # update the target to compile with C++11
+if(benchmark_ADDED)
+  # Don't use C++14 because it doesn't work in some configurations.
   set_target_properties(benchmark PROPERTIES CXX_STANDARD 11)
 endif()
 ```

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ CPMAddPackage(
 )
 
 if(benchmark_ADDED)
-  # Don't use C++14 because it doesn't work in some configurations.
+  # enable c++11 to avoid compilation errors
   set_target_properties(benchmark PROPERTIES CXX_STANDARD 11)
 endif()
 ```

--- a/README.md
+++ b/README.md
@@ -82,6 +82,44 @@ After calling `CPMAddPackage` or `CPMFindPackage`, the following variables are d
 The difference between `CPMFindPackage` and `CPMAddPackage` is that `CPMFindPackage` will try to find a local dependency via CMake's `find_package` and fallback to `CPMAddPackage` if the dependency is not found.
 This behaviour can be also modified globally via [CPM options](#options).
 
+## Full CMakeLists Example
+
+```cmake
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+
+# create project
+project(MyProject)
+
+# add executable
+add_executable(tests tests.cpp)
+
+# add dependencies
+include(cmake/CPM.cmake)
+CPMAddPackage("gh:catchorg/Catch2@2.5.0")
+
+# link dependencies
+target_link_libraries(tests Catch2)
+```
+
+See the [examples directory](https://github.com/cpm-cmake/CPM.cmake/tree/master/examples) for complete examples with source code and check [below](#snippets) or in the [wiki](https://github.com/cpm-cmake/CPM.cmake/wiki/More-Snippets) for example snippets.
+
+## Adding CPM
+
+To add CPM to your current project, simply add the [latest release](https://github.com/cpm-cmake/CPM.cmake/releases/latest) of `CPM.cmake` or `get_cpm.cmake` to your project's `cmake` directory.
+The command below will perform this automatically.
+
+```bash
+mkdir -p cmake
+wget -O cmake/CPM.cmake https://github.com/cpm-cmake/CPM.cmake/releases/latest/download/get_cpm.cmake
+```
+
+You can also download CPM.cmake directly from your project's `CMakeLists.txt`. See the [wiki](https://github.com/cpm-cmake/CPM.cmake/wiki/Downloading-CPM.cmake-in-CMake) for more details.
+
+## Updating CPM
+
+To update CPM to the newest version, update the script in the project's root directory, for example by running the command above.
+Dependencies using CPM will automatically use the updated script of the outermost project.
+
 ## Advantages
 
 - **Small and reusable projects** CPM takes care of all project dependencies, allowing developers to focus on creating small, well-tested libraries.

--- a/README.md
+++ b/README.md
@@ -278,47 +278,23 @@ CPMAddPackage(gh:Orphis/boost-cmake@1.67.0)
 ### [cxxopts](https://github.com/jarro2783/cxxopts)
 
 ```cmake
-CPMAddPackage(
-  NAME cxxopts
-  GITHUB_REPOSITORY jarro2783/cxxopts
-  VERSION 2.2.0
-  OPTIONS
-    "CXXOPTS_BUILD_EXAMPLES Off"
-    "CXXOPTS_BUILD_TESTS Off"
-)
+CPMAddPackage("gh:jarro2783/cxxopts@2.2.0")
 ```
 
 ### [Yaml-cpp](https://github.com/jbeder/yaml-cpp)
 
 ```CMake
-CPMAddPackage(
-  NAME yaml-cpp
-  GITHUB_REPOSITORY jbeder/yaml-cpp
-  # 0.6.2 uses deprecated CMake syntax
-  VERSION 0.6.3
-  # 0.6.3 is not released yet, so use a recent commit
-  GIT_TAG 012269756149ae99745b6dafefd415843d7420bb
-  OPTIONS
-    "YAML_CPP_BUILD_TESTS Off"
-    "YAML_CPP_BUILD_CONTRIB Off"
-    "YAML_CPP_BUILD_TOOLS Off"
-)
+CPMAddPackage("gh:jbeder/yaml-cpp#yaml-cpp-0.6.3@0.6.3")
 ```
 
 ### [google/benchmark](https://github.com/google/benchmark)
 
 ```cmake
-CPMAddPackage(
-  NAME benchmark
-  GITHUB_REPOSITORY google/benchmark
-  VERSION 1.4.1
-  OPTIONS
-    "BENCHMARK_ENABLE_TESTING Off"
-)
+CPMAddPackage("gh:google/benchmark@1.5.2")
 
 if (benchmark_ADDED)
-  # compile with C++17
-  set_target_properties(benchmark PROPERTIES CXX_STANDARD 17)
+  # update the target to compile with C++11
+  set_target_properties(benchmark PROPERTIES CXX_STANDARD 11)
 endif()
 ```
 

--- a/examples/asio-standalone/CMakeLists.txt
+++ b/examples/asio-standalone/CMakeLists.txt
@@ -8,12 +8,7 @@ include(../../cmake/CPM.cmake)
 
 find_package(Threads REQUIRED)
 
-CPMAddPackage(
-  NAME asio
-  VERSION 1.18.1
-  GITHUB_REPOSITORY chriskohlhoff/asio
-  GIT_TAG asio-1-18-1 # asio uses non-standard version tag, we must specify GIT_TAG
-)
+CPMAddPackage("gh:chriskohlhoff/asio#asio-1-18-1@1.18.1")
 
 # ASIO doesn't use CMake, we have to configure it manually. Extra notes for using on Windows:
 #

--- a/examples/benchmark/CMakeLists.txt
+++ b/examples/benchmark/CMakeLists.txt
@@ -8,7 +8,12 @@ include(../../cmake/CPM.cmake)
 
 CPMAddPackage("gh:TheLartians/Fibonacci@2.0")
 
-CPMAddPackage("gh:google/benchmark@1.5.2")
+CPMAddPackage(
+  NAME benchmark
+  GITHUB_REPOSITORY google/benchmark
+  VERSION 1.5.2
+  OPTIONS "BENCHMARK_ENABLE_TESTING Off"
+)
 
 if(benchmark_ADDED)
   # Don't use C++14 because it doesn't work in some configurations.

--- a/examples/benchmark/CMakeLists.txt
+++ b/examples/benchmark/CMakeLists.txt
@@ -16,7 +16,7 @@ CPMAddPackage(
 )
 
 if(benchmark_ADDED)
-  # Don't use C++14 because it doesn't work in some configurations.
+  # enable c++11 to avoid compilation errors
   set_target_properties(benchmark PROPERTIES CXX_STANDARD 11)
 endif()
 

--- a/examples/benchmark/CMakeLists.txt
+++ b/examples/benchmark/CMakeLists.txt
@@ -8,12 +8,7 @@ include(../../cmake/CPM.cmake)
 
 CPMAddPackage("gh:TheLartians/Fibonacci@2.0")
 
-CPMAddPackage(
-  NAME benchmark
-  GITHUB_REPOSITORY google/benchmark
-  VERSION 1.5.2
-  OPTIONS "BENCHMARK_ENABLE_TESTING Off"
-)
+CPMAddPackage("gh:google/benchmark@1.5.2")
 
 if(benchmark_ADDED)
   # Don't use C++14 because it doesn't work in some configurations.

--- a/examples/boost/CMakeLists.txt
+++ b/examples/boost/CMakeLists.txt
@@ -15,6 +15,7 @@ CPMFindPackage(
   NAME Boost
   GITHUB_REPOSITORY Orphis/boost-cmake
   VERSION 1.67.0
+  # setting FIND_PACKAGE_ARGUMENTS allow usage with `CPM_USE_LOCAL_PACKAGES`
   FIND_PACKAGE_ARGUMENTS "COMPONENTS system"
 )
 

--- a/examples/cxxopts/CMakeLists.txt
+++ b/examples/cxxopts/CMakeLists.txt
@@ -6,12 +6,7 @@ project(CPMExampleCXXOpts)
 
 include(../../cmake/CPM.cmake)
 
-CPMAddPackage(
-  NAME cxxopts
-  GITHUB_REPOSITORY jarro2783/cxxopts
-  VERSION 2.2.0
-  OPTIONS "CXXOPTS_BUILD_EXAMPLES Off" "CXXOPTS_BUILD_TESTS Off"
-)
+CPMAddPackage("gh:jarro2783/cxxopts@2.2.0")
 
 # ---- Create binary ----
 

--- a/examples/yaml/CMakeLists.txt
+++ b/examples/yaml/CMakeLists.txt
@@ -6,13 +6,7 @@ project(CPMYamlExample)
 
 include(../../cmake/CPM.cmake)
 
-CPMAddPackage(
-  NAME yaml-cpp
-  GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
-  VERSION 0.6.3
-  GIT_TAG yaml-cpp-0.6.3
-  OPTIONS "YAML_CPP_BUILD_TESTS Off" "YAML_CPP_BUILD_CONTRIB Off" "YAML_CPP_BUILD_TOOLS Off"
-)
+CPMAddPackage("gh:jbeder/yaml-cpp#yaml-cpp-0.6.3@0.6.3")
 
 # ---- Executable ----
 


### PR DESCRIPTION
Thanks to `EXCLUDE_FROM_ALL` being active by default, we should be able to update even more examples to use the awesome new shorthand syntax without worrying about leaking examples or tests into the main build.