### PR TITLE
Update more examples from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,16 +283,21 @@ CPMAddPackage("gh:Orphis/boost-cmake@1.67.0")
 CPMAddPackage("gh:jbeder/yaml-cpp#yaml-cpp-0.6.3@0.6.3")
 ```
 
-### [nlohmann/json](https://github.com/nlohmann/json)
-
-```cmake
-CPMAddPackage("gh:nlohmann/json@3.9.1")
-```
-
 ### [Range-v3](https://github.com/ericniebler/range-v3)
 
 ```Cmake
 CPMAddPackage("gh:ericniebler/range-v3#0.11.0")
+```
+
+### [nlohmann/json](https://github.com/nlohmann/json)
+
+```cmake
+CPMAddPackage(
+  NAME nlohmann_json
+  VERSION 3.9.1
+  OPTIONS 
+    "JSON_BuildTests OFF"
+)
 ```
 
 ### [cxxopts](https://github.com/jarro2783/cxxopts)

--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ CPMAddPackage("gh:Orphis/boost-cmake@1.67.0")
 ### [Yaml-cpp](https://github.com/jbeder/yaml-cpp)
 
 ```CMake
+# as the tag is in an unusual format, we need to explicitly specify the version
 CPMAddPackage("gh:jbeder/yaml-cpp#yaml-cpp-0.6.3@0.6.3")
 ```
 
@@ -297,6 +298,7 @@ CPMAddPackage("gh:ericniebler/range-v3#0.11.0")
 ### [cxxopts](https://github.com/jarro2783/cxxopts)
 
 ```cmake
+# the install option has to be explicitly set to allow installation
 CPMAddPackage(
   GITHUB_REPOSITORY jarro2783/cxxopts
   VERSION 2.2.1

--- a/README.md
+++ b/README.md
@@ -276,6 +276,24 @@ CPMAddPackage("gh:catchorg/Catch2@2.5.0")
 CPMAddPackage("gh:Orphis/boost-cmake@1.67.0")
 ```
 
+### [Yaml-cpp](https://github.com/jbeder/yaml-cpp)
+
+```CMake
+CPMAddPackage("gh:jbeder/yaml-cpp#yaml-cpp-0.6.3@0.6.3")
+```
+
+### [nlohmann/json](https://github.com/nlohmann/json)
+
+```cmake
+CPMAddPackage("gh:nlohmann/json@3.9.1")
+```
+
+### [Range-v3](https://github.com/ericniebler/range-v3)
+
+```Cmake
+CPMAddPackage("gh:ericniebler/range-v3#0.11.0")
+```
+
 ### [cxxopts](https://github.com/jarro2783/cxxopts)
 
 ```cmake
@@ -284,12 +302,6 @@ CPMAddPackage(
   VERSION 2.2.1
   OPTIONS "CXXOPTS_BUILD_EXAMPLES NO" "CXXOPTS_BUILD_TESTS NO" "CXXOPTS_ENABLE_INSTALL YES"
 )
-```
-
-### [Yaml-cpp](https://github.com/jbeder/yaml-cpp)
-
-```CMake
-CPMAddPackage("gh:jbeder/yaml-cpp#yaml-cpp-0.6.3@0.6.3")
 ```
 
 ### [google/benchmark](https://github.com/google/benchmark)
@@ -305,40 +317,6 @@ CPMAddPackage(
 if(benchmark_ADDED)
   # enable c++11 to avoid compilation errors
   set_target_properties(benchmark PROPERTIES CXX_STANDARD 11)
-endif()
-```
-
-### [nlohmann/json](https://github.com/nlohmann/json)
-
-```cmake
-CPMAddPackage(
-  NAME nlohmann_json
-  VERSION 3.6.1
-  # the git repo is incredibly large, so we download the archived include directory
-  URL https://github.com/nlohmann/json/releases/download/v3.6.1/include.zip
-  URL_HASH SHA256=69cc88207ce91347ea530b227ff0776db82dcb8de6704e1a3d74f4841bc651cf
-)
-
-if (nlohmann_json_ADDED)
-  add_library(nlohmann_json INTERFACE IMPORTED)
-  target_include_directories(nlohmann_json INTERFACE ${nlohmann_json_SOURCE_DIR})
-endif()
-```
-
-### [Range-v3](https://github.com/ericniebler/range-v3)
-
-```Cmake
-CPMAddPackage(
-  NAME range-v3
-  URL https://github.com/ericniebler/range-v3/archive/0.5.0.zip
-  VERSION 0.5.0
-  # the range-v3 CMakeLists screws with configuration options
-  DOWNLOAD_ONLY True
-)
-
-if(range-v3_ADDED)
-  add_library(range-v3 INTERFACE IMPORTED)
-  target_include_directories(range-v3 INTERFACE "${range-v3_SOURCE_DIR}/include")
 endif()
 ```
 

--- a/examples/json/CMakeLists.txt
+++ b/examples/json/CMakeLists.txt
@@ -5,22 +5,10 @@ project(CPMJSONExample)
 # ---- Dependencies ----
 
 include(../../cmake/CPM.cmake)
-
-CPMAddPackage(
-  NAME nlohmann_json
-  VERSION 3.9.1
-  # not using the repo as it takes forever to clone
-  URL https://github.com/nlohmann/json/releases/download/v3.9.1/include.zip
-  URL_HASH SHA256=6bea5877b1541d353bd77bdfbdb2696333ae5ed8f9e8cc22df657192218cad91
-)
-
-if(nlohmann_json_ADDED)
-  add_library(nlohmann_json INTERFACE)
-  target_include_directories(nlohmann_json SYSTEM INTERFACE ${nlohmann_json_SOURCE_DIR}/include)
-endif()
+CPMAddPackage("gh:nlohmann/json@3.9.1")
 
 # ---- Executable ----
 
 add_executable(CPMJSONExample main.cpp)
 target_compile_features(CPMJSONExample PRIVATE cxx_std_17)
-target_link_libraries(CPMJSONExample nlohmann_json)
+target_link_libraries(CPMJSONExample nlohmann_json::nlohmann_json)

--- a/examples/range-v3/CMakeLists.txt
+++ b/examples/range-v3/CMakeLists.txt
@@ -6,18 +6,7 @@ project(CPMRangev3Example)
 
 include(../../cmake/CPM.cmake)
 
-CPMAddPackage(
-  NAME range-v3
-  URL https://github.com/ericniebler/range-v3/archive/0.11.0.zip
-  VERSION 0.11.0
-  # the range-v3 CMakeLists screws with configuration options
-  DOWNLOAD_ONLY True
-)
-
-if(range-v3_ADDED)
-  add_library(range-v3 INTERFACE IMPORTED)
-  target_include_directories(range-v3 SYSTEM INTERFACE "${range-v3_SOURCE_DIR}/include")
-endif()
+CPMAddPackage("gh:ericniebler/range-v3#0.11.0")
 
 # ---- Executable ----
 

--- a/examples/range-v3/main.cpp
+++ b/examples/range-v3/main.cpp
@@ -32,7 +32,7 @@ auto is_six = [](int i) { return i == 6; };
 int main() {
   std::vector<int> v{6, 2, 3, 4, 5, 6};
   cout << std::boolalpha;
-  cout << "vector: " << ranges::view::all(v) << '\n';
+  cout << "vector: " << ranges::views::all(v) << '\n';
 
   cout << "vector any_of is_six: " << ranges::any_of(v, is_six) << '\n';
   cout << "vector all_of is_six: " << ranges::all_of(v, is_six) << '\n';


### PR DESCRIPTION
Following some user confusion in my C++ starter project, I've updated some of the examples to make them use a more trivial syntax where possible. This is also a good time to do so, as the previous arguments of large downloads and unnecessary targets have been resolved thanks to shallow clones and the `EXCLUDE_FROM_ALL` option.