### PR TITLE
Update boost-cmake example

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,10 @@ CPMAddPackage("gh:catchorg/Catch2@2.5.0")
 ### [Boost (via boost-cmake)](https://github.com/Orphis/boost-cmake)
 
 ```CMake
-CPMAddPackage("gh:Orphis/boost-cmake@1.67.0")
+# boost-cmake currently doesn't tag versions
+CPMAddPackage(
+  "gh:Orphis/boost-cmake#7f97a08b64bd5d2e53e932ddf80c40544cf45edf@1.71.0"
+)
 ```
 
 ### [Yaml-cpp](https://github.com/jbeder/yaml-cpp)

--- a/README.md
+++ b/README.md
@@ -273,10 +273,8 @@ CPMAddPackage("gh:catchorg/Catch2@2.5.0")
 ### [Boost (via boost-cmake)](https://github.com/Orphis/boost-cmake)
 
 ```CMake
-# boost-cmake currently doesn't tag versions
-CPMAddPackage(
-  "gh:Orphis/boost-cmake#7f97a08b64bd5d2e53e932ddf80c40544cf45edf@1.71.0"
-)
+# boost-cmake currently doesn't tag versions, so we use the according boost version
+CPMAddPackage("gh:Orphis/boost-cmake#7f97a08b64bd5d2e53e932ddf80c40544cf45edf@1.71.0")
 ```
 
 ### [Yaml-cpp](https://github.com/jbeder/yaml-cpp)

--- a/examples/boost/CMakeLists.txt
+++ b/examples/boost/CMakeLists.txt
@@ -11,12 +11,9 @@ target_compile_features(CPMExampleBoost PRIVATE cxx_std_17)
 
 include(../../cmake/CPM.cmake)
 
-CPMFindPackage(
-  NAME Boost
-  GITHUB_REPOSITORY Orphis/boost-cmake
-  VERSION 1.67.0
-  # setting FIND_PACKAGE_ARGUMENTS allow usage with `CPM_USE_LOCAL_PACKAGES`
-  FIND_PACKAGE_ARGUMENTS "COMPONENTS system"
+# boost-cmake currently doesn't tag versions
+CPMAddPackage(
+  "gh:Orphis/boost-cmake#7f97a08b64bd5d2e53e932ddf80c40544cf45edf@1.71.0"
 )
 
 find_package(Threads REQUIRED)

--- a/examples/boost/CMakeLists.txt
+++ b/examples/boost/CMakeLists.txt
@@ -11,10 +11,8 @@ target_compile_features(CPMExampleBoost PRIVATE cxx_std_17)
 
 include(../../cmake/CPM.cmake)
 
-# boost-cmake currently doesn't tag versions
-CPMAddPackage(
-  "gh:Orphis/boost-cmake#7f97a08b64bd5d2e53e932ddf80c40544cf45edf@1.71.0"
-)
+# boost-cmake currently doesn't tag versions, so we use the according boost version
+CPMAddPackage("gh:Orphis/boost-cmake#7f97a08b64bd5d2e53e932ddf80c40544cf45edf@1.71.0")
 
 find_package(Threads REQUIRED)
 

--- a/examples/cxxopts/main.cpp
+++ b/examples/cxxopts/main.cpp
@@ -3,8 +3,8 @@
 
 int main(int argc, char** argv) {
   cxxopts::Options options("MyProgram", "One line description of MyProgram");
-  options.add_options()("h,help", "Show help")("d,debug", "Enable debugging")(
-      "f,file", "File name", cxxopts::value<std::string>());
+  options.add_options()("h,help", "Show help")(
+      "d,debug", "Enable debugging")("f,file", "File name", cxxopts::value<std::string>());
 
   auto result = options.parse(argc, argv);
 


### PR DESCRIPTION
This should fix the broken travis build due to a hash mismatch.