### PR TITLE
Expand relative download directory to prevent unnecessary download

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -531,6 +531,8 @@ function(CPMAddPackage)
     list(SORT origin_parameters)
     string(SHA1 origin_hash "${origin_parameters}")
     set(download_directory ${CPM_SOURCE_CACHE}/${lower_case_name}/${origin_hash})
+    # Expand `download_directory` relative path. This is important because EXISTS doesn't work for relative paths.
+    get_filename_component(download_directory ${download_directory} ABSOLUTE)
     list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS SOURCE_DIR ${download_directory})
     if(EXISTS ${download_directory})
       # avoid FetchContent modules to improve performance

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -531,7 +531,8 @@ function(CPMAddPackage)
     list(SORT origin_parameters)
     string(SHA1 origin_hash "${origin_parameters}")
     set(download_directory ${CPM_SOURCE_CACHE}/${lower_case_name}/${origin_hash})
-    # Expand `download_directory` relative path. This is important because EXISTS doesn't work for relative paths.
+    # Expand `download_directory` relative path. This is important because EXISTS doesn't work for
+    # relative paths.
     get_filename_component(download_directory ${download_directory} ABSOLUTE)
     list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS SOURCE_DIR ${download_directory})
     if(EXISTS ${download_directory})


### PR DESCRIPTION
If `CMAKE_SOURCE_CACHE` (and thus `download_directory` in `CPMAddPackage`) is set to a relative path, the condition `if(EXISTS ${download_directory})` will fail even if the required directory exists. Expanding the variable `download_directory` to an absolute path before the test will rectify this, preventing unnecessary downloads of the sources.

### Motivation

I've looked at CPM (vs. vcpkg, conan and others) a couple of times before, and been put off by lengthy re-configure times. I've realised that this is because I've specified the cache directory as a relative path (e.g. with `set(CPM_SOURCE_CACHE ../.cpm_cache CACHE PATH "CPM download cache" FORCE)` in my main `CMakeLists.txt`). I could change *my* code, but I figure if it's done inside CPM, then others may also benefit.

I'll certainly be using CPM in the future now I've sussed why I was having issues previously.