### PR TITLE
Fix CPMAddPackage when FetchContent_MakeAvailable already added package

### DIFF
--- a/test/unit/fetchcontent_dependency.cmake
+++ b/test/unit/fetchcontent_dependency.cmake
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+
+include(${CPM_PATH}/testing.cmake)
+include(CMakePackageConfigHelpers)
+
+set(CPM_SOURCE_CACHE_DIR "${CMAKE_CURRENT_BINARY_DIR}/CPM")
+set(TEST_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/fetchcontent_dependency)
+
+function(clear_cache)
+  message(STATUS "clearing CPM cache")
+  file(REMOVE_RECURSE ${CPM_SOURCE_CACHE_DIR})
+  assert_not_exists("${CPM_SOURCE_CACHE_DIR}")
+endfunction()
+
+function(update_cmake_lists)
+  configure_package_config_file(
+    "${CMAKE_CURRENT_LIST_DIR}/fetchcontent_dependency/CMakeLists.txt.in"
+    "${CMAKE_CURRENT_LIST_DIR}/fetchcontent_dependency/CMakeLists.txt"
+    INSTALL_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/junk
+  )
+endfunction()
+
+function(reset_test)
+  clear_cache()
+  file(REMOVE_RECURSE ${TEST_BUILD_DIR})
+  update_cmake_lists()
+endfunction()
+
+# Read CPM_SOURCE_CACHE from arguments
+
+reset_test()
+
+execute_process(
+  COMMAND ${CMAKE_COMMAND} "-H${CMAKE_CURRENT_LIST_DIR}/fetchcontent_dependency"
+          "-B${TEST_BUILD_DIR}" "-DCPM_SOURCE_CACHE=${CPM_SOURCE_CACHE_DIR}" RESULT_VARIABLE ret
+)
+
+assert_equal(${ret} "0")

--- a/test/unit/fetchcontent_dependency/.gitignore
+++ b/test/unit/fetchcontent_dependency/.gitignore
@@ -1,0 +1,2 @@
+/CMakeLists.txt
+/package-lock.cmake

--- a/test/unit/fetchcontent_dependency/CMakeLists.txt.in
+++ b/test/unit/fetchcontent_dependency/CMakeLists.txt.in
@@ -1,0 +1,38 @@
+# ~~~
+#    ┌────────────────────────┐
+#    │ FetchContentDependency │
+#    └─────┬────────────┬─────┘
+#          │1.          │3.
+#          │            │
+# ┌────────▼────┐   ┌───▼─────────┐
+# │ Dependency  ├───►  Fibonacci  │
+# └─────────────┘2. └─────────────┘
+#
+# 1. Add Project with CPMAddPackage
+# 2. Dependency will add Fibonacci with FetchContent
+# 3. Our project add Fibonacci with CPMAddPackage
+# ~~~
+
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+
+project(CPMTest_FetchContentDependency)
+
+# ---- Dependencies ----
+
+include(@CPM_PATH@/CPM.cmake)
+
+# 1 & 2 Dependency will add Fibonacci using FetchContent (1 & 2)
+CPMAddPackage(NAME Dependency SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/dependency)
+
+# 3 Add again Fibonacci that have already been populated with FetchContent_MakeAvailable
+#
+# * This test should highlight the fact that cpm_add_subdirectory is always called, even when
+#   cpm_fetch_package isn't populating the dependency
+# * NO_CACHE YES highlight a bug introduced in 32b063eba5c754f833725ed4b9e5f352bc3ca959 where
+#   cpm_fetch_package was checking undefined ${lower_case_name}_POPULATED variable
+CPMAddPackage(
+  NAME Fibonacci
+  GIT_REPOSITORY https://github.com/cpm-cmake/testpack-fibonacci.git
+  VERSION 2.0
+  NO_CACHE YES
+)

--- a/test/unit/fetchcontent_dependency/dependency/CMakeLists.txt
+++ b/test/unit/fetchcontent_dependency/dependency/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+
+project(CPMTest_Dependency)
+
+# ---- Dependencies ----
+
+include(FetchContent)
+
+FetchContent_Declare(
+  Fibonacci
+  GIT_REPOSITORY https://github.com/cpm-cmake/testpack-fibonacci.git
+  GIT_TAG v2.0
+)
+
+FetchContent_MakeAvailable(Fibonacci)


### PR DESCRIPTION
Add fetchcontent_dependency unit test:
* This test should highlight the fact that cpm_add_subdirectory is always called, even when
  cpm_fetch_package isn't populating the dependency
* NO_CACHE YES highlight a bug introduced in 32b063eba5c754f833725ed4b9e5f352bc3ca959 where
  cpm_fetch_package was checking undefined ${lower_case_name}_POPULATED variable

fix https://github.com/cpm-cmake/CPM.cmake/issues/287