### PR TITLE
Fix the case where option is a list

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -869,21 +869,27 @@ function(cpm_parse_option OPTION)
   string(REGEX MATCH "^[^ ]+" OPTION_KEY ${OPTION})
   string(LENGTH ${OPTION} OPTION_LENGTH)
   string(LENGTH ${OPTION_KEY} OPTION_KEY_LENGTH)
+
   if(OPTION_KEY_LENGTH STREQUAL OPTION_LENGTH)
     # no value for key provided, assume user wants to set option to "ON"
     set(OPTION_VALUE "ON")
   else()
     math(EXPR OPTION_KEY_LENGTH "${OPTION_KEY_LENGTH}+1")
     string(SUBSTRING ${OPTION} "${OPTION_KEY_LENGTH}" "-1" OPTION_VALUE)
+    string(STRIP ${OPTION_VALUE} OPTION_VALUE)
+    string(REGEX REPLACE "[ ]+" ";" OPTION_VALUE ${OPTION_VALUE})
   endif()
+
   set(OPTION_KEY
-      "${OPTION_KEY}"
-      PARENT_SCOPE
-  )
+    "${OPTION_KEY}"
+    PARENT_SCOPE
+    )
+
   set(OPTION_VALUE
-      "${OPTION_VALUE}"
-      PARENT_SCOPE
-  )
+    "${OPTION_VALUE}"
+    PARENT_SCOPE
+    )
+
 endfunction()
 
 # guesses the package version from a git tag


### PR DESCRIPTION
Should fix #291 but you need to declare lists like this 
```cmake
CPMAddPackage(
  NAME cxxopts
  GITHUB_REPOSITORY jarro2783/cxxopts
  VERSION 2.2.0
  OPTIONS
  "CXXOPTS_BUILD_EXAMPLES  Off "
  "CXXOPTS_BUILD_TESTS  Off "
  "STUPID_OPTION  opt  1       yes    \"tmp\"       "
)
```