### PR TITLE
add warning when not using release version of CPM.cmake

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -57,6 +57,13 @@ See https://github.com/cpm-cmake/CPM.cmake for more information."
   endif()
 endif()
 
+if(CURRENT_CPM_VERSION MATCHES "development-version")
+  message(WARNING "Your project is using an unstable development version of CPM.cmake. \
+Please update to a recent release if possible. \
+See https://github.com/cpm-cmake/CPM.cmake for details."
+  )
+endif()
+
 set_property(GLOBAL PROPERTY CPM_INITIALIZED true)
 
 option(CPM_USE_LOCAL_PACKAGES "Always try to use `find_package` to get dependencies"


### PR DESCRIPTION
Adds a warning for using the development version of CPM.cmake (e.g. by downloading the source from the master branch) instead of a using stable release as documented in the readme.