### PR TITLE
Use official boost release in examples / readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,11 +274,15 @@ See the [wiki](https://github.com/cpm-cmake/CPM.cmake/wiki/More-Snippets) for mo
 CPMAddPackage("gh:catchorg/Catch2@2.5.0")
 ```
 
-### [Boost (via boost-cmake)](https://github.com/Orphis/boost-cmake)
+### [Boost ](https://github.com/boostorg/boost)
 
 ```CMake
-# boost-cmake currently doesn't tag versions, so we use the according boost version
-CPMAddPackage("gh:Orphis/boost-cmake#7f97a08b64bd5d2e53e932ddf80c40544cf45edf@1.71.0")
+CPMAddPackage(
+  NAME Boost
+  VERSION 1.77.0
+  GITHUB_REPOSITORY "boostorg/boost"
+  GIT_TAG "boost-1.77.0"
+)
 ```
 
 ### [Yaml-cpp](https://github.com/jbeder/yaml-cpp)

--- a/examples/boost/CMakeLists.txt
+++ b/examples/boost/CMakeLists.txt
@@ -11,9 +11,11 @@ target_compile_features(CPMExampleBoost PRIVATE cxx_std_17)
 
 include(../../cmake/CPM.cmake)
 
-# boost-cmake currently doesn't tag versions, so we use the according boost version
-CPMAddPackage("gh:Orphis/boost-cmake#7f97a08b64bd5d2e53e932ddf80c40544cf45edf@1.71.0")
+CPMAddPackage(
+  NAME Boost
+  VERSION 1.77.0
+  GITHUB_REPOSITORY "boostorg/boost"
+  GIT_TAG "boost-1.77.0"
+)
 
-find_package(Threads REQUIRED)
-
-target_link_libraries(CPMExampleBoost PRIVATE Boost::system Threads::Threads)
+target_link_libraries(CPMExampleBoost PRIVATE Boost::asio)


### PR DESCRIPTION
As discussed in #300, we can now use the official Boost library, as it appears that proper CMake support has been added to the library!