### PR TITLE
Fix <package>_SOURCE_DIR and _BINARY_DIR handling when caching is active

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -619,8 +619,11 @@ function(CPMAddPackage)
     get_filename_component(download_directory ${download_directory} ABSOLUTE)
     list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS SOURCE_DIR ${download_directory})
     if(EXISTS ${download_directory})
-	  cpm_store_fetch_properties(${CPM_ARGS_NAME} "${download_directory}" "${CPM_FETCHCONTENT_BASE_DIR}/${lower_case_name}-build")
-	  cpm_get_fetch_properties("${CPM_ARGS_NAME}")
+      cpm_store_fetch_properties(
+        ${CPM_ARGS_NAME} "${download_directory}"
+        "${CPM_FETCHCONTENT_BASE_DIR}/${lower_case_name}-build"
+      )
+      cpm_get_fetch_properties("${CPM_ARGS_NAME}")
 
       if(DEFINED CPM_ARGS_GIT_TAG)
         # warn if cache has been changed since checkout
@@ -807,8 +810,14 @@ function(cpm_store_fetch_properties PACKAGE source_dir binary_dir)
     return()
   endif()
 
-  set(CPM_PACKAGE_${PACKAGE}_SOURCE_DIR "${source_dir}" CACHE INTERNAL "")
-  set(CPM_PACKAGE_${PACKAGE}_BINARY_DIR "${binary_dir}" CACHE INTERNAL "")
+  set(CPM_PACKAGE_${PACKAGE}_SOURCE_DIR
+      "${source_dir}"
+      CACHE INTERNAL ""
+  )
+  set(CPM_PACKAGE_${PACKAGE}_BINARY_DIR
+      "${binary_dir}"
+      CACHE INTERNAL ""
+  )
 endfunction()
 
 # adds a package as a subdirectory if viable, according to provided options
@@ -867,8 +876,10 @@ function(cpm_fetch_package PACKAGE populated)
         PARENT_SCOPE
     )
   endif()
-  
-  cpm_store_fetch_properties(${CPM_ARGS_NAME} ${${lower_case_name}_SOURCE_DIR} ${${lower_case_name}_BINARY_DIR})
+
+  cpm_store_fetch_properties(
+    ${CPM_ARGS_NAME} ${${lower_case_name}_SOURCE_DIR} ${${lower_case_name}_BINARY_DIR}
+  )
 
   set(${PACKAGE}_SOURCE_DIR
       ${${lower_case_name}_SOURCE_DIR}


### PR DESCRIPTION
Today I struggled a bit with a project of mine, where I used ``CPMAddPackage`` on exactly the same dependency but on different hirarchies of my project. The first add was fine, but the second did neither set the ``<package>_SOURCE_DIR`` nor ``<package>_BINARY_DIR``.
There are some other issues around, that might be related to this topic (#227 #281 )

I did some code digging and this is what I think causes the issue:
The first ``CPMAddPackage`` runs until the end of the function, but because the package is already in the local cache, it will skip the fetch case (~Line 672). Because of this skip, ``FetchContent`` doesn't know about the package. When ``CPMAddPackage`` is called the next time on the same package, ``CPM`` already knows that the package has been added (around line 536) and trys to load the ``SOURCE_DIR`` and ``BINARY_DIR`` from the ``FetchContent``, but those have never been set, thus both variables will be empty.

My solution is to utilize the cmake cache mechanism, but I really don't know if thats the best way to do it. Feel free to correct me ;)