### PR TITLE
Remove badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-[![Actions Status](https://github.com/cpm-cmake/CPM.cmake/workflows/MacOS/badge.svg)](https://github.com/cpm-cmake/CPM.cmake/actions)
-[![Actions Status](https://github.com/cpm-cmake/CPM.cmake/workflows/Windows/badge.svg)](https://github.com/cpm-cmake/CPM.cmake/actions)
-[![Actions Status](https://github.com/cpm-cmake/CPM.cmake/workflows/Ubuntu/badge.svg)](https://github.com/cpm-cmake/CPM.cmake/actions)
 
 <br />
 <p align="center">
@@ -10,7 +7,7 @@
 
 # Setup-free CMake dependency management
 
-CPM.cmake is a CMake script that adds dependency management capabilities to CMake.
+CPM.cmake is a cross-platform CMake script that adds dependency management capabilities to CMake.
 It's built as a thin wrapper around CMake's [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) module that adds version control, caching, a simple API [and more](#comparison-to-pure-fetchcontent--externalproject).
 
 ## Manage everything


### PR DESCRIPTION
As we now use the unified CI workflow (#326), it seems we unfortunately [can't have separate badges for each OS](https://github.community/t/separate-workflow-badges-when-using-matrix-testing-possible/16708). As the display of the badges was to reference the cross-platform nature of the project, imo it can be replaced by adding a reference in the introduction instead.