### PR TITLE
[Example] Disable JSON tests being included in ctest

### DIFF
--- a/examples/json/CMakeLists.txt
+++ b/examples/json/CMakeLists.txt
@@ -5,6 +5,8 @@ project(CPMJSONExample)
 # ---- Dependencies ----
 
 include(../../cmake/CPM.cmake)
+# Disable building json tests that pollute the project's ctest environment 
+set(JSON_BuildTests OFF CACHE INTERNAL "")
 CPMAddPackage("gh:nlohmann/json@3.9.1")
 
 # ---- Executable ----


### PR DESCRIPTION
If `CPMAddPackage` includes json without setting JSON_BuildTests off first then the target's ctest will include lots of json's tests. This is probably undesired for folks that just want to use json to build their code.