### PR TITLE
Allows set/set(CACHE) to behave the same as set(X)/option(x)

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -841,6 +841,12 @@ function(
       cmake_policy(SET CMP0077 NEW)
       set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
+      # the policy allows us to change set(CACHE) without caching
+      if(POLICY CMP0126)
+        cmake_policy(SET CMP0126 NEW)
+        set(CMAKE_POLICY_DEFAULT_CMP0126 NEW)
+      endif()
+
       foreach(OPTION ${OPTIONS})
         cpm_parse_option("${OPTION}")
         set(${OPTION_KEY} "${OPTION_VALUE}")


### PR DESCRIPTION
By enabling CMP0126 we tell CMake that when constructing a CACHE variable
with the same name as a local variable to not unset the local variable.

By enabling CMPO126 it makes sure that CPM behavior around `OPTION` is
consistent if the option is created with `set(CACHE)` or with `option`.