### PR TITLE
Fix beginner’s trap / fix broken example for nlohmann/json

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ CPMAddPackage("gh:jbeder/yaml-cpp#yaml-cpp-0.6.3@0.6.3")
 CPMAddPackage(
   NAME nlohmann_json
   VERSION 3.9.1
+  GITHUB_REPOSITORY nlohmann/json
   OPTIONS 
     "JSON_BuildTests OFF"
 )


### PR DESCRIPTION
The example for nlohmann_json is wrong. It's missing the download source.

Without this fix, my builds fails with this message: `No download info given for 'nlohmann_json-populate' and its source
  directory:`


Even the maintainer of nlohmann_json says (https://github.com/nlohmann/json#package-managers) that it should be:
```
CPMAddPackage(
    NAME nlohmann_json
    GITHUB_REPOSITORY nlohmann/json
    VERSION 3.9.1)
```    

