### PR TITLE
Allow overriding FetchContent using CPM

### DIFF
--- a/test/integration/fetchcontent_compatibility.rb
+++ b/test/integration/fetchcontent_compatibility.rb
@@ -1,6 +1,6 @@
 require_relative './lib'
 
-# Tests with source cache
+# Tests FetchContent overriding with CPM
 
 class SourceCache < IntegrationTest
   def setup

--- a/test/integration/fetchcontent_compatibility.rb
+++ b/test/integration/fetchcontent_compatibility.rb
@@ -1,0 +1,41 @@
+require_relative './lib'
+
+# Tests with source cache
+
+class SourceCache < IntegrationTest
+  def setup
+    @cache_dir = File.join(cur_test_dir, 'cpmcache')
+    ENV['CPM_SOURCE_CACHE'] = @cache_dir
+  end
+
+  def test_add_dependency_cpm_and_fetchcontent
+    prj = make_project 'using-adder'
+    
+    prj.create_lists_from_default_template package: <<~PACK
+    CPMAddPackage(
+      NAME testpack-adder
+      GITHUB_REPOSITORY cpm-cmake/testpack-adder
+      VERSION 1.0.0
+      OPTIONS "ADDER_BUILD_TESTS OFF"
+    )
+
+    # should have no effect, as we added the dependency using CPM
+    FetchContent_Declare(
+      testpack-adder
+      GIT_REPOSITORY https://github.com/cpm-cmake/testpack-adder
+      GIT_TAG        v1.0.0
+    )
+
+    FetchContent_MakeAvailable(testpack-adder)
+    PACK
+
+    # configure with unpopulated cache
+    assert_success prj.configure
+    assert_success prj.build
+
+    # configure with populated cache
+    assert_success prj.configure
+    assert_success prj.build
+  end
+
+end

--- a/test/integration/fetchcontent_compatibility.rb
+++ b/test/integration/fetchcontent_compatibility.rb
@@ -33,6 +33,9 @@ class SourceCache < IntegrationTest
     assert_success prj.configure
     assert_success prj.build
 
+    # cache is populated
+    assert_true File.exist?(File.join(@cache_dir, "testpack-adder"))
+
     # configure with populated cache
     assert_success prj.configure
     assert_success prj.build

--- a/test/integration/test_fetchcontent_compatibility.rb
+++ b/test/integration/test_fetchcontent_compatibility.rb
@@ -12,21 +12,20 @@ class FetchContentCompatibility < IntegrationTest
     prj = make_project 'using-adder'
     
     prj.create_lists_from_default_template package: <<~PACK
-    CPMAddPackage(
-      NAME testpack-adder
-      GITHUB_REPOSITORY cpm-cmake/testpack-adder
-      VERSION 1.0.0
-      OPTIONS "ADDER_BUILD_TESTS OFF"
-    )
+      CPMAddPackage(
+        NAME testpack-adder
+        GITHUB_REPOSITORY cpm-cmake/testpack-adder
+        VERSION 1.0.0
+        OPTIONS "ADDER_BUILD_TESTS OFF"
+      )
 
-    # should have no effect, as we added the dependency using CPM
-    FetchContent_Declare(
-      testpack-adder
-      GIT_REPOSITORY https://github.com/cpm-cmake/testpack-adder
-      GIT_TAG        v1.0.0
-    )
-
-    FetchContent_MakeAvailable(testpack-adder)
+      # should have no effect, as we added the dependency using CPM
+      FetchContent_Declare(
+        testpack-adder
+        GIT_REPOSITORY https://github.com/cpm-cmake/testpack-adder
+        GIT_TAG v1.0.0
+      )
+      FetchContent_MakeAvailable(testpack-adder)
     PACK
 
     # configure with unpopulated cache

--- a/test/integration/test_fetchcontent_compatibility.rb
+++ b/test/integration/test_fetchcontent_compatibility.rb
@@ -2,7 +2,7 @@ require_relative './lib'
 
 # Tests FetchContent overriding with CPM
 
-class SourceCache < IntegrationTest
+class FetchContentCompatibility < IntegrationTest
   def setup
     @cache_dir = File.join(cur_test_dir, 'cpmcache')
     ENV['CPM_SOURCE_CACHE'] = @cache_dir


### PR DESCRIPTION
This should allow using CPM.cmake to override FetchContent dependencies by overriding internal FetchContent parameters.

Fixes #281 
