### PR TITLE
Add readme "Customize repository URL" with git-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,41 @@ For using CPM.cmake projects with external package managers, such as conan or vc
 
 In rare cases, this behaviour may be desirable by default. The function `CPMFindPackage` will try to find a local dependency via CMake's `find_package` and fallback to `CPMAddPackage`, if the dependency is not found.
 
+### Customize repository URL
+
+When using a private repository, it could be tempting to write URL with authentication token, which can be be quite annoying to maintain, hard to use, can lead to cache misses if `CI_TOKEN` often change, etc... 
+
+```cmake
+# Don't do this.
+CPMAddPackage("https://${CI_USERNAME}:${CI_TOKEN}@example.com/my-package")
+```
+
+It is recommended to use [git-config](https://git-scm.com/docs/git-config) to handle such cases.
+
+```bash
+CI_USERNAME=your_username
+CI_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Github
+git config --global url."https://$CI_USERNAME:$CI_TOKEN@github.com".insteadOf "https://github.com"
+
+CI_JOB_TOKEN = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Gitlab
+# More info: https://docs.gitlab.com/ee/ci/jobs/ci_job_token.html
+git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.company.com".insteadOf "https://gitlab.company.com"
+
+# Edit your config file
+git config --global --edit
+```
+
+This trick can also be used to modify from where a dependency is coming from:
+
+```bash
+# Overwrite googletest with a self hosted google test version
+git config --global url."https://github.com/company/googletest".insteadOf "https://github.com/google/googletest"
+```
+
 ## Full CMakeLists Example
 
 ```cmake

--- a/README.md
+++ b/README.md
@@ -231,10 +231,14 @@ See the [wiki](https://github.com/cpm-cmake/CPM.cmake/wiki/Package-lock) for mor
 
 When using CPM.cmake with private repositories, there may be a need to provide an [access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) to be able to clone other projects. Instead of providing the token in CMake, we recommend to provide the regular URL and use [git-config](https://git-scm.com/docs/git-config) to rewrite the URLs to include the token.
 
+As an example, you could include one of the following in your CI script.
+
 ```bash
 # Github
 git config --global url."https://${USERNAME}:${TOKEN}@github.com".insteadOf "https://github.com"
+```
 
+```bash
 # GitLab
 git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.com".insteadOf "https://gitlab.com"
 ```

--- a/README.md
+++ b/README.md
@@ -78,41 +78,6 @@ For using CPM.cmake projects with external package managers, such as conan or vc
 
 In rare cases, this behaviour may be desirable by default. The function `CPMFindPackage` will try to find a local dependency via CMake's `find_package` and fallback to `CPMAddPackage`, if the dependency is not found.
 
-### Customize repository URL
-
-When using a private repository, it could be tempting to write URL with authentication token, which can be be quite annoying to maintain, hard to use, can lead to cache misses if `CI_TOKEN` often change, etc... 
-
-```cmake
-# Don't do this.
-CPMAddPackage("https://${CI_USERNAME}:${CI_TOKEN}@example.com/my-package")
-```
-
-It is recommended to use [git-config](https://git-scm.com/docs/git-config) to handle such cases.
-
-```bash
-CI_USERNAME=your_username
-CI_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-
-# Github
-git config --global url."https://$CI_USERNAME:$CI_TOKEN@github.com".insteadOf "https://github.com"
-
-CI_JOB_TOKEN = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-
-# Gitlab
-# More info: https://docs.gitlab.com/ee/ci/jobs/ci_job_token.html
-git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.company.com".insteadOf "https://gitlab.company.com"
-
-# Edit your config file
-git config --global --edit
-```
-
-This trick can also be used to modify from where a dependency is coming from:
-
-```bash
-# Overwrite googletest with a self hosted google test version
-git config --global url."https://github.com/company/googletest".insteadOf "https://github.com/google/googletest"
-```
-
 ## Full CMakeLists Example
 
 ```cmake
@@ -261,6 +226,18 @@ cmake --build build --target cpm-update-package-lock
 ```
 
 See the [wiki](https://github.com/cpm-cmake/CPM.cmake/wiki/Package-lock) for more info.
+
+## Private repositories and CI
+
+When using CPM.cmake with private repositories, there may be a need to provide an [access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) to be able to clone other projects. Instead of providing the token in CMake, we recommend to provide the regular URL and use [git-config](https://git-scm.com/docs/git-config) to rewrite the URLs to include the token.
+
+```bash
+# Github
+git config --global url."https://${USERNAME}:${TOKEN}@github.com".insteadOf "https://github.com"
+
+# GitLab
+git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.com".insteadOf "https://gitlab.com"
+```
 
 ## Built with CPM.cmake
 


### PR DESCRIPTION
From https://github.com/cpm-cmake/CPM.cmake/issues/350

### Customize repository URL

When using a private repository, it could be tempting to write URL with authentication token, which can be be quite annoying to maintain, hard to use, can lead to cache misses if `CI_TOKEN` often change, etc... 

```cmake
# Don't do this.
CPMAddPackage("https://${CI_USERNAME}:${CI_TOKEN}@example.com/my-package")
```

It is recommended to use [git-config](https://git-scm.com/docs/git-config) to handle such cases.

```bash
CI_USERNAME=your_username
CI_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

# Github
git config --global url."https://$CI_USERNAME:$CI_TOKEN@github.com".insteadOf "https://github.com"

CI_JOB_TOKEN = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

# Gitlab
# More info: https://docs.gitlab.com/ee/ci/jobs/ci_job_token.html
git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.company.com".insteadOf "https://gitlab.company.com"

# Edit your config file
git config --global --edit
```

This trick can also be used to modify from where a dependency is coming from:

```bash
# Overwrite googletest with a self hosted google test version
git config --global url."https://github.com/company/googletest".insteadOf "https://github.com/google/googletest"
```