### PR TITLE
Instead of spdlog's bundled fmt re-use it from CPM.cmake

### DIFF
--- a/examples/spdlog/CMakeLists.txt
+++ b/examples/spdlog/CMakeLists.txt
@@ -8,15 +8,11 @@ include(../../cmake/CPM.cmake)
 
 CPMAddPackage("gh:gabime/spdlog@1.8.2")
 
-# spdlog uses fmt and bundles that dependency. If you want to use fmt in your 
-# project as well, you can let spdlog re-use fmt from CPM.cmake like this:
+# spdlog uses fmt and bundles that dependency. If you want to use fmt in your project as well, you
+# can let spdlog re-use fmt from CPM.cmake like this:
 #
-# CPMAddPackage("gh:fmtlib/fmt#7.1.3")
-# CPMAddPackage(
-#   GITHUB_REPOSITORY gabime/spdlog
-#   VERSION 1.8.2
-#   OPTIONS "SPDLOG_FMT_EXTERNAL 1"
-# )
+# CPMAddPackage("gh:fmtlib/fmt#7.1.3") CPMAddPackage( GITHUB_REPOSITORY gabime/spdlog VERSION 1.8.2
+# OPTIONS "SPDLOG_FMT_EXTERNAL 1" )
 
 # ---- Executable ----
 

--- a/examples/spdlog/CMakeLists.txt
+++ b/examples/spdlog/CMakeLists.txt
@@ -6,7 +6,12 @@ project(CPMSpdlogExample)
 
 include(../../cmake/CPM.cmake)
 
-CPMAddPackage("gh:gabime/spdlog@1.8.2")
+CPMAddPackage("gh:fmtlib/fmt#7.1.3")
+CPMAddPackage(
+  GITHUB_REPOSITORY gabime/spdlog
+  VERSION 1.8.2
+  OPTIONS "SPDLOG_FMT_EXTERNAL 1"
+)
 
 # ---- Executable ----
 

--- a/examples/spdlog/CMakeLists.txt
+++ b/examples/spdlog/CMakeLists.txt
@@ -11,8 +11,16 @@ CPMAddPackage("gh:gabime/spdlog@1.8.2")
 # spdlog uses fmt and bundles that dependency. If you want to use fmt in your project as well, you
 # can let spdlog re-use fmt from CPM.cmake like this:
 #
-# CPMAddPackage("gh:fmtlib/fmt#7.1.3") CPMAddPackage( GITHUB_REPOSITORY gabime/spdlog VERSION 1.8.2
-# OPTIONS "SPDLOG_FMT_EXTERNAL 1" )
+# cmake-format: off
+#
+# CPMAddPackage("gh:fmtlib/fmt#7.1.3") 
+# CPMAddPackage(
+#   GITHUB_REPOSITORY gabime/spdlog 
+#   VERSION 1.8.2 
+#   OPTIONS "SPDLOG_FMT_EXTERNAL 1" 
+# )
+#
+# cmake-format: on
 
 # ---- Executable ----
 

--- a/examples/spdlog/CMakeLists.txt
+++ b/examples/spdlog/CMakeLists.txt
@@ -8,8 +8,8 @@ include(../../cmake/CPM.cmake)
 
 CPMAddPackage("gh:gabime/spdlog@1.8.2")
 
-# spdlog uses fmt and bundles that dependency. If you want to use fmt anyway,
-# you can let spdlog re-use fmt from CPM.cmake like this:
+# spdlog uses fmt and bundles that dependency. If you want to use fmt in your 
+# project as well, you can let spdlog re-use fmt from CPM.cmake like this:
 #
 # CPMAddPackage("gh:fmtlib/fmt#7.1.3")
 # CPMAddPackage(

--- a/examples/spdlog/CMakeLists.txt
+++ b/examples/spdlog/CMakeLists.txt
@@ -6,12 +6,17 @@ project(CPMSpdlogExample)
 
 include(../../cmake/CPM.cmake)
 
-CPMAddPackage("gh:fmtlib/fmt#7.1.3")
-CPMAddPackage(
-  GITHUB_REPOSITORY gabime/spdlog
-  VERSION 1.8.2
-  OPTIONS "SPDLOG_FMT_EXTERNAL 1"
-)
+CPMAddPackage("gh:gabime/spdlog@1.8.2")
+
+# spdlog uses fmt and bundles that dependency. If you want to use fmt anyway,
+# you can let spdlog re-use fmt from CPM.cmake like this:
+#
+# CPMAddPackage("gh:fmtlib/fmt#7.1.3")
+# CPMAddPackage(
+#   GITHUB_REPOSITORY gabime/spdlog
+#   VERSION 1.8.2
+#   OPTIONS "SPDLOG_FMT_EXTERNAL 1"
+# )
 
 # ---- Executable ----
 


### PR DESCRIPTION
I think this is a good example. If someone wants to stick to the bundled one it's easier to remove the OPTION than to add it otherwise.