### PR TITLE
bump example range-v3 to 0.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ CPMAddPackage("gh:catchorg/Catch2@2.5.0")
 ### [Range-v3](https://github.com/ericniebler/range-v3)
 
 ```Cmake
-CPMAddPackage("gh:ericniebler/range-v3#0.11.0")
+CPMAddPackage("gh:ericniebler/range-v3#0.12.0")
 ```
 
 ### [Yaml-cpp](https://github.com/jbeder/yaml-cpp)

--- a/examples/range-v3/CMakeLists.txt
+++ b/examples/range-v3/CMakeLists.txt
@@ -6,7 +6,7 @@ project(CPMRangev3Example)
 
 include(../../cmake/CPM.cmake)
 
-CPMAddPackage("gh:ericniebler/range-v3#0.11.0")
+CPMAddPackage("gh:ericniebler/range-v3#0.12.0")
 
 # ---- Executable ----
 


### PR DESCRIPTION
range-v3 recently got its 0.12.0 release: https://github.com/ericniebler/range-v3/releases/tag/0.12.0