### PR TITLE
Timestamps for URL downloads match the download time

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,13 @@ In the case that `find_package` requires additional arguments, the parameter `FI
 If set, CPM use additional directory level in cache to improve readability of packages names in IDEs like CLion. It changes cache structure, so all dependencies are downloaded again. There is no problem to mix both structures in one cache directory but then there may be 2 copies of some dependencies.
 This can also be set as an environmental variable.
 
+### CPM_SET_RECOMMENDED_CMAKE_POLICIES
+If set, CPM will default the following CMake policies to `NEW` for all packages brought
+in via CPM
+  * CMP0077 - The option() command does nothing when a normal variable of the given name already exists.
+  * CMP0126 - The set(CACHE) command will not remove an existing normal variable of the given name.
+  * CMP0135 - Use the download time for timestamps, instead of the timestamps in the archive. This allows for proper rebuilds when a projects url changes
+
 ## Local package override
 
 Library developers are often in the situation where they work on a locally checked out dependency at the same time as on a consumer project.

--- a/README.md
+++ b/README.md
@@ -198,14 +198,6 @@ In the case that `find_package` requires additional arguments, the parameter `FI
 If set, CPM use additional directory level in cache to improve readability of packages names in IDEs like CLion. It changes cache structure, so all dependencies are downloaded again. There is no problem to mix both structures in one cache directory but then there may be 2 copies of some dependencies.
 This can also be set as an environmental variable.
 
-### CPM_SET_RECOMMENDED_CMAKE_POLICIES
-
-If set, CPM will default the following CMake policies to `NEW` for all packages brought in via CPM.
-
-  * [CMP0077](https://cmake.org/cmake/help/latest/policy/CMP0077.html) - The option() command does nothing when a normal variable of the given name already exists.
-  * [CMP0126](https://cmake.org/cmake/help/latest/policy/CMP0126.html) - The set(CACHE) command will not remove an existing normal variable of the given name.
-  * [CMP0135](https://cmake.org/cmake/help/latest/policy/CMP0135.html) - Use the download time for timestamps, instead of the timestamps in the archive. This allows for proper rebuilds when a projects url changes.
-
 ## Local package override
 
 Library developers are often in the situation where they work on a locally checked out dependency at the same time as on a consumer project.

--- a/README.md
+++ b/README.md
@@ -199,11 +199,12 @@ If set, CPM use additional directory level in cache to improve readability of pa
 This can also be set as an environmental variable.
 
 ### CPM_SET_RECOMMENDED_CMAKE_POLICIES
-If set, CPM will default the following CMake policies to `NEW` for all packages brought
-in via CPM
-  * CMP0077 - The option() command does nothing when a normal variable of the given name already exists.
-  * CMP0126 - The set(CACHE) command will not remove an existing normal variable of the given name.
-  * CMP0135 - Use the download time for timestamps, instead of the timestamps in the archive. This allows for proper rebuilds when a projects url changes
+
+If set, CPM will default the following CMake policies to `NEW` for all packages brought in via CPM.
+
+  * [CMP0077](https://cmake.org/cmake/help/latest/policy/CMP0077.html) - The option() command does nothing when a normal variable of the given name already exists.
+  * [CMP0126](https://cmake.org/cmake/help/latest/policy/CMP0126.html) - The set(CACHE) command will not remove an existing normal variable of the given name.
+  * [CMP0135](https://cmake.org/cmake/help/latest/policy/CMP0135.html) - Use the download time for timestamps, instead of the timestamps in the archive. This allows for proper rebuilds when a projects url changes.
 
 ## Local package override
 

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -115,7 +115,6 @@ set(CPM_SET_RECOMMENDED_CMAKE_POLICIES
 
 if(CPM_SET_RECOMMENDED_CMAKE_POLICIES)
   # the policy allows us to change options without caching
-  cmake_policy(PUSH)
   cmake_policy(SET CMP0077 NEW)
   set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -595,13 +595,6 @@ function(CPMAddPackage)
     endif()
 
     list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS URL "${CPM_ARGS_URL}")
-
-    # Prefer to use the download time for timestamp, instead of the timestamp in the archive unless
-    # explicitly set by user. This allows for proper rebuilds when a projects url changes
-    if(POLICY CMP0135)
-      cmake_policy(SET CMP0135 NEW)
-      set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
-    endif()
   endif()
 
   # Check for required arguments

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -255,8 +255,8 @@ macro(cpm_set_cmake_policies)
       set(CMAKE_POLICY_DEFAULT_CMP0126 NEW)
     endif()
 
-    # The policy uses the download time for timestamp, instead of the timestamp in the archive.
-    # This allows for proper rebuilds when a projects url changes
+    # The policy uses the download time for timestamp, instead of the timestamp in the archive. This
+    # allows for proper rebuilds when a projects url changes
     if(POLICY CMP0135)
       cmake_policy(SET CMP0135 NEW)
       set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -28,6 +28,23 @@
 
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
+# the policy allows us to change options without caching
+cmake_policy(SET CMP0077 NEW)
+set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+
+# the policy allows us to change set(CACHE) without caching
+if(POLICY CMP0126)
+  cmake_policy(SET CMP0126 NEW)
+  set(CMAKE_POLICY_DEFAULT_CMP0126 NEW)
+endif()
+
+# The policy uses the download time for timestamp, instead of the timestamp in the archive. This
+# allows for proper rebuilds when a projects url changes
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+  set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
+endif()
+
 set(CURRENT_CPM_VERSION 1.0.0-development-version)
 
 if(CPM_DIRECTORY)
@@ -108,29 +125,6 @@ set(CPM_DRY_RUN
     OFF
     CACHE INTERNAL "Don't download or configure dependencies (for testing)"
 )
-set(CPM_SET_RECOMMENDED_CMAKE_POLICIES
-    ON
-    CACHE INTERNAL "Have CPM enable all recommended CMake policies"
-)
-
-if(CPM_SET_RECOMMENDED_CMAKE_POLICIES)
-  # the policy allows us to change options without caching
-  cmake_policy(SET CMP0077 NEW)
-  set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
-
-  # the policy allows us to change set(CACHE) without caching
-  if(POLICY CMP0126)
-    cmake_policy(SET CMP0126 NEW)
-    set(CMAKE_POLICY_DEFAULT_CMP0126 NEW)
-  endif()
-
-  # The policy uses the download time for timestamp, instead of the timestamp in the archive. This
-  # allows for proper rebuilds when a projects url changes
-  if(POLICY CMP0135)
-    cmake_policy(SET CMP0135 NEW)
-    set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
-  endif()
-endif()
 
 if(DEFINED ENV{CPM_SOURCE_CACHE})
   set(CPM_SOURCE_CACHE_DEFAULT $ENV{CPM_SOURCE_CACHE})

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -113,6 +113,26 @@ set(CPM_SET_RECOMMENDED_CMAKE_POLICIES
     CACHE INTERNAL "Have CPM enable all recommended CMake policies"
 )
 
+if(CPM_SET_RECOMMENDED_CMAKE_POLICIES)
+  # the policy allows us to change options without caching
+  cmake_policy(PUSH)
+  cmake_policy(SET CMP0077 NEW)
+  set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+
+  # the policy allows us to change set(CACHE) without caching
+  if(POLICY CMP0126)
+    cmake_policy(SET CMP0126 NEW)
+    set(CMAKE_POLICY_DEFAULT_CMP0126 NEW)
+  endif()
+
+  # The policy uses the download time for timestamp, instead of the timestamp in the archive. This
+  # allows for proper rebuilds when a projects url changes
+  if(POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+    set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
+  endif()
+endif()
+
 if(DEFINED ENV{CPM_SOURCE_CACHE})
   set(CPM_SOURCE_CACHE_DEFAULT $ENV{CPM_SOURCE_CACHE})
 else()
@@ -243,30 +263,8 @@ function(cpm_create_module_file Name)
   endif()
 endfunction()
 
-macro(cpm_set_cmake_policies)
-  if(CPM_SET_RECOMMENDED_CMAKE_POLICIES)
-    # the policy allows us to change options without caching
-    cmake_policy(SET CMP0077 NEW)
-    set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
-
-    # the policy allows us to change set(CACHE) without caching
-    if(POLICY CMP0126)
-      cmake_policy(SET CMP0126 NEW)
-      set(CMAKE_POLICY_DEFAULT_CMP0126 NEW)
-    endif()
-
-    # The policy uses the download time for timestamp, instead of the timestamp in the archive. This
-    # allows for proper rebuilds when a projects url changes
-    if(POLICY CMP0135)
-      cmake_policy(SET CMP0135 NEW)
-      set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
-    endif()
-  endif()
-endmacro()
-
 # Find a package locally or fallback to CPMAddPackage
 function(CPMFindPackage)
-  cpm_set_cmake_policies()
   set(oneValueArgs NAME VERSION GIT_TAG FIND_PACKAGE_ARGUMENTS)
 
   cmake_parse_arguments(CPM_ARGS "" "${oneValueArgs}" "" ${ARGN})
@@ -502,7 +500,6 @@ endfunction()
 
 # Download and add a package from source
 function(CPMAddPackage)
-  cpm_set_cmake_policies()
 
   list(LENGTH ARGN argnLength)
   if(argnLength EQUAL 1)
@@ -919,16 +916,6 @@ function(
       set(addSubdirectoryExtraArgs "")
     endif()
     if(OPTIONS)
-      # the policy allows us to change options without caching
-      cmake_policy(SET CMP0077 NEW)
-      set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
-
-      # the policy allows us to change set(CACHE) without caching
-      if(POLICY CMP0126)
-        cmake_policy(SET CMP0126 NEW)
-        set(CMAKE_POLICY_DEFAULT_CMP0126 NEW)
-      endif()
-
       foreach(OPTION ${OPTIONS})
         cpm_parse_option("${OPTION}")
         set(${OPTION_KEY} "${OPTION_VALUE}")

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -109,7 +109,7 @@ set(CPM_DRY_RUN
     CACHE INTERNAL "Don't download or configure dependencies (for testing)"
 )
 set(CPM_SET_RECOMMENDED_CMAKE_POLICIES
-    OFF
+    ON
     CACHE INTERNAL "Have CPM enable all recommended CMake policies"
 )
 

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -567,6 +567,13 @@ function(CPMAddPackage)
     endif()
 
     list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS URL "${CPM_ARGS_URL}")
+
+    # Prefer to use the download time for timestamp, instead of the timestamp in the archive unless
+    # explicitly set by user. This allows for proper rebuilds when a projects url changes
+    if(POLICY CMP0135)
+      cmake_policy(SET CMP0135 NEW)
+      set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
+    endif()
   endif()
 
   # Check for required arguments


### PR DESCRIPTION
By enabling CMake policy 135 we ensure that extracted files timestamp match that of the download time, instead of when the archive is created. This makes sure that if the URL changes to an older version we still rebuild everything as the timestamp
stays newer.