### PR TITLE
Add Methane Kit project to showcase table in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,14 @@ If you know others, feel free to add them here through a PR.
         <p align="center"><b>klogg - fast advanced log explorer</b></p>
       </a>
     </td>
+    <td>
+      <a href="https://github.com/MethanePowered/MethaneKit">
+        <p align="center">
+          <img src="https://github.com/MethanePowered/MethaneKit/raw/master/Docs/Images/Logo/MethaneLogoSmall.png" alt="MethaneKit" width="100pt" />
+        </p>
+        <p align="center"><b>Methane Kit - modern 3D graphics framework and rendering abstraction API on top of DirectX 12, Metal & Vulkan</b></p>
+      </a>
+    </td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -290,12 +290,14 @@ If you know others, feel free to add them here through a PR.
         <p align="center"><b>klogg - fast advanced log explorer</b></p>
       </a>
     </td>
+  </tr>
+  <tr>
     <td>
       <a href="https://github.com/MethanePowered/MethaneKit">
         <p align="center">
           <img src="https://github.com/MethanePowered/MethaneKit/raw/master/Docs/Images/Logo/MethaneLogoSmall.png" alt="MethaneKit" width="100pt" />
         </p>
-        <p align="center"><b>Methane Kit - modern 3D graphics framework and rendering abstraction API on top of DirectX 12, Metal & Vulkan</b></p>
+        <p align="center"><b>Methane Kit - modern 3D graphics rendering framework</b></p>
       </a>
     </td>
   </tr>


### PR DESCRIPTION
[Methane Kit](https://github.com/MethanePowered/MethaneKit) project was recently migrated from [using Git submodules](https://github.com/egorodet/MethaneExternals) to CPM.cmake for external dependencies management, which greatly simplified dependency updates and allowed reusing the same dependencies in the derived projects without code duplication (for example [MethaneAsteroids](https://github.com/MethanePowered/MethaneAsteroids)). Please add Methane Kit to the CPM showcase table, if it's well suited for demonstration needs.