### PR TITLE
Small helper function for logging :

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -28,15 +28,25 @@
 
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
+if (NOT DEFINED CPM_INDENT)
+  set(CPM_INDENT "CPM: ")
+endif ()
+
+if (NOT COMMAND cpm_message)
+  function(cpm_message)
+    message(${ARGV})
+  endfunction()
+endif ()
+
 set(CURRENT_CPM_VERSION 1.0.0-development-version)
 
 get_filename_component(CPM_CURRENT_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" REALPATH)
-if(CPM_DIRECTORY)
-  if(NOT CPM_DIRECTORY STREQUAL CPM_CURRENT_DIRECTORY)
-    if(CPM_VERSION VERSION_LESS CURRENT_CPM_VERSION)
+if (CPM_DIRECTORY)
+  if (NOT CPM_DIRECTORY STREQUAL CPM_CURRENT_DIRECTORY)
+    if (CPM_VERSION VERSION_LESS CURRENT_CPM_VERSION)
       message(
-        AUTHOR_WARNING
-          "${CPM_INDENT} \
+              AUTHOR_WARNING
+              "${CPM_INDENT} \
 A dependency is using a more recent CPM version (${CURRENT_CPM_VERSION}) than the current project (${CPM_VERSION}). \
 It is recommended to upgrade CPM to the most recent version. \
 See https://github.com/cpm-cmake/CPM.cmake for more information."
@@ -59,10 +69,10 @@ See https://github.com/cpm-cmake/CPM.cmake for more information."
 endif()
 
 if(CURRENT_CPM_VERSION MATCHES "development-version")
-  message(WARNING "Your project is using an unstable development version of CPM.cmake. \
+  message(WARNING "${CPM_INDENT} Your project is using an unstable development version of CPM.cmake. \
 Please update to a recent release if possible. \
 See https://github.com/cpm-cmake/CPM.cmake for details."
-  )
+          )
 endif()
 
 set_property(GLOBAL PROPERTY CPM_INITIALIZED true)
@@ -238,7 +248,7 @@ function(cpm_find_package NAME VERSION)
     if(DEFINED ${CPM_ARGS_NAME}_VERSION)
       set(VERSION ${${CPM_ARGS_NAME}_VERSION})
     endif()
-    message(STATUS "${CPM_INDENT} using local package ${CPM_ARGS_NAME}@${VERSION}")
+    cpm_message(STATUS "${CPM_INDENT} Using local package ${CPM_ARGS_NAME}@${VERSION}")
     CPMRegisterPackage(${CPM_ARGS_NAME} "${VERSION}")
     set(CPM_PACKAGE_FOUND
         YES
@@ -308,8 +318,8 @@ function(cpm_check_if_package_already_added CPM_ARGS_NAME CPM_ARGS_VERSION)
     CPMGetPackageVersion(${CPM_ARGS_NAME} CPM_PACKAGE_VERSION)
     if("${CPM_PACKAGE_VERSION}" VERSION_LESS "${CPM_ARGS_VERSION}")
       message(
-        WARNING
-          "${CPM_INDENT} requires a newer version of ${CPM_ARGS_NAME} (${CPM_ARGS_VERSION}) than currently included (${CPM_PACKAGE_VERSION})."
+              WARNING
+              "${CPM_INDENT} Requires a newer version of ${CPM_ARGS_NAME} (${CPM_ARGS_VERSION}) than currently included (${CPM_PACKAGE_VERSION})."
       )
     endif()
     cpm_get_fetch_properties(${CPM_ARGS_NAME})
@@ -366,7 +376,7 @@ function(cpm_parse_add_package_single_arg arg outArgs)
       set(packageType "git")
     else()
       # Give up
-      message(FATAL_ERROR "CPM: Can't determine package type of '${arg}'")
+      message(FATAL_ERROR "${CPM_INDENT} Can't determine package type of '${arg}'")
     endif()
   endif()
 
@@ -386,7 +396,7 @@ function(cpm_parse_add_package_single_arg arg outArgs)
   else()
     # We should never get here. This is an assertion and hitting it means there's a bug in the code
     # above. A packageType was set, but not handled by this if-else.
-    message(FATAL_ERROR "CPM: Unsupported package type '${packageType}' of '${arg}'")
+    message(FATAL_ERROR "${CPM_INDENT} Unsupported package type '${packageType}' of '${arg}'")
   endif()
 
   set(${outArgs}
@@ -419,11 +429,11 @@ function(cpm_check_git_working_dir_is_clean repoPath gitTag isClean)
   )
   if(resultGitStatus)
     # not supposed to happen, assume clean anyway
-    message(WARNING "Calling git status on folder ${repoPath} failed")
+    message(WARNING "${CPM_INDENT} Calling git status on folder ${repoPath} failed")
     set(${isClean}
-        TRUE
-        PARENT_SCOPE
-    )
+            TRUE
+            PARENT_SCOPE
+            )
     return()
   endif()
 
@@ -464,7 +474,7 @@ endfunction()
 function(cpm_override_fetchcontent contentName)
   cmake_parse_arguments(PARSE_ARGV 1 arg "" "SOURCE_DIR;BINARY_DIR" "")
   if(NOT "${arg_UNPARSED_ARGUMENTS}" STREQUAL "")
-    message(FATAL_ERROR "Unsupported arguments: ${arg_UNPARSED_ARGUMENTS}")
+    message(FATAL_ERROR "${CPM_INDENT} Unsupported arguments: ${arg_UNPARSED_ARGUMENTS}")
   endif()
 
   string(TOLOWER ${contentName} contentNameLower)
@@ -599,8 +609,8 @@ function(CPMAddPackage)
 
   if(NOT DEFINED CPM_ARGS_NAME)
     message(
-      FATAL_ERROR
-        "CPM: 'NAME' was not provided and couldn't be automatically inferred for package added with arguments: '${ARGN}'"
+            FATAL_ERROR
+            "${CPM_INDENT} 'NAME' was not provided and couldn't be automatically inferred for package added with arguments: '${ARGN}'"
     )
   endif()
 
@@ -649,8 +659,8 @@ function(CPMAddPackage)
 
     if(CPM_LOCAL_PACKAGES_ONLY)
       message(
-        SEND_ERROR
-          "CPM: ${CPM_ARGS_NAME} not found via find_package(${CPM_ARGS_NAME} ${CPM_ARGS_VERSION})"
+              SEND_ERROR
+              "${CPM_INDENT} ${CPM_ARGS_NAME} not found via find_package(${CPM_ARGS_NAME} ${CPM_ARGS_VERSION})"
       )
     endif()
   endif()
@@ -716,7 +726,7 @@ function(CPMAddPackage)
         # warn if cache has been changed since checkout
         cpm_check_git_working_dir_is_clean(${download_directory} ${CPM_ARGS_GIT_TAG} IS_CLEAN)
         if(NOT ${IS_CLEAN})
-          message(WARNING "Cache for ${CPM_ARGS_NAME} (${download_directory}) is dirty")
+          message(WARNING "${CPM_INDENT} Cache for ${CPM_ARGS_NAME} (${download_directory}) is dirty")
         endif()
       endif()
 
@@ -752,28 +762,28 @@ function(CPMAddPackage)
 
   cpm_create_module_file(${CPM_ARGS_NAME} "CPMAddPackage(\"${ARGN}\")")
 
-  if(CPM_PACKAGE_LOCK_ENABLED)
-    if((CPM_ARGS_VERSION AND NOT CPM_ARGS_SOURCE_DIR) OR CPM_INCLUDE_ALL_IN_PACKAGE_LOCK)
+  if (CPM_PACKAGE_LOCK_ENABLED)
+    if ((CPM_ARGS_VERSION AND NOT CPM_ARGS_SOURCE_DIR) OR CPM_INCLUDE_ALL_IN_PACKAGE_LOCK)
       cpm_add_to_package_lock(${CPM_ARGS_NAME} "${ARGN}")
-    elseif(CPM_ARGS_SOURCE_DIR)
+    elseif (CPM_ARGS_SOURCE_DIR)
       cpm_add_comment_to_package_lock(${CPM_ARGS_NAME} "local directory")
-    else()
+    else ()
       cpm_add_comment_to_package_lock(${CPM_ARGS_NAME} "${ARGN}")
-    endif()
-  endif()
+    endif ()
+  endif ()
 
-  message(
-    STATUS "${CPM_INDENT} adding package ${CPM_ARGS_NAME}@${CPM_ARGS_VERSION} (${PACKAGE_INFO})"
+  cpm_message(
+          STATUS "${CPM_INDENT} Adding package ${CPM_ARGS_NAME}@${CPM_ARGS_VERSION} (${PACKAGE_INFO})"
   )
 
-  if(NOT CPM_SKIP_FETCH)
+  if (NOT CPM_SKIP_FETCH)
     cpm_declare_fetch(
-      "${CPM_ARGS_NAME}" "${CPM_ARGS_VERSION}" "${PACKAGE_INFO}" "${CPM_ARGS_UNPARSED_ARGUMENTS}"
+            "${CPM_ARGS_NAME}" "${CPM_ARGS_VERSION}" "${PACKAGE_INFO}" "${CPM_ARGS_UNPARSED_ARGUMENTS}"
     )
     cpm_fetch_package("${CPM_ARGS_NAME}" populated)
-    if(${populated})
+    if (${populated})
       cpm_add_subdirectory(
-        "${CPM_ARGS_NAME}" "${DOWNLOAD_ONLY}"
+              "${CPM_ARGS_NAME}" "${DOWNLOAD_ONLY}"
         "${${CPM_ARGS_NAME}_SOURCE_DIR}/${CPM_ARGS_SOURCE_SUBDIR}" "${${CPM_ARGS_NAME}_BINARY_DIR}"
         "${CPM_ARGS_EXCLUDE_FROM_ALL}" "${CPM_ARGS_OPTIONS}"
       )
@@ -790,7 +800,7 @@ macro(CPMGetPackage Name)
   if(DEFINED "CPM_DECLARATION_${Name}")
     CPMAddPackage(NAME ${Name})
   else()
-    message(SEND_ERROR "Cannot retrieve package ${Name}: no declaration available")
+    message(SEND_ERROR "${CPM_INDENT} Cannot retrieve package ${Name}: no declaration available")
   endif()
 endmacro()
 
@@ -880,7 +890,7 @@ endfunction()
 # declares a package in FetchContent_Declare
 function(cpm_declare_fetch PACKAGE VERSION INFO)
   if(${CPM_DRY_RUN})
-    message(STATUS "${CPM_INDENT} package not declared (dry run)")
+    cpm_message(STATUS "${CPM_INDENT} Package not declared (dry run)")
     return()
   endif()
 
@@ -955,7 +965,7 @@ function(cpm_fetch_package PACKAGE populated)
       PARENT_SCOPE
   )
   if(${CPM_DRY_RUN})
-    message(STATUS "${CPM_INDENT} package ${PACKAGE} not fetched (dry run)")
+    cpm_message(STATUS "${CPM_INDENT} Package ${PACKAGE} not fetched (dry run)")
     return()
   endif()
 

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -28,25 +28,29 @@
 
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
-if (NOT DEFINED CPM_INDENT)
-  set(CPM_INDENT "CPM: ")
-endif ()
+# Initialize logging prefix
+if(NOT CPM_INDENT)
+  set(CPM_INDENT
+      "CPM:"
+      CACHE INTERNAL ""
+  )
+endif()
 
-if (NOT COMMAND cpm_message)
+if(NOT COMMAND cpm_message)
   function(cpm_message)
     message(${ARGV})
   endfunction()
-endif ()
+endif()
 
 set(CURRENT_CPM_VERSION 1.0.0-development-version)
 
 get_filename_component(CPM_CURRENT_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" REALPATH)
-if (CPM_DIRECTORY)
-  if (NOT CPM_DIRECTORY STREQUAL CPM_CURRENT_DIRECTORY)
-    if (CPM_VERSION VERSION_LESS CURRENT_CPM_VERSION)
+if(CPM_DIRECTORY)
+  if(NOT CPM_DIRECTORY STREQUAL CPM_CURRENT_DIRECTORY)
+    if(CPM_VERSION VERSION_LESS CURRENT_CPM_VERSION)
       message(
-              AUTHOR_WARNING
-              "${CPM_INDENT} \
+        AUTHOR_WARNING
+          "${CPM_INDENT} \
 A dependency is using a more recent CPM version (${CURRENT_CPM_VERSION}) than the current project (${CPM_VERSION}). \
 It is recommended to upgrade CPM to the most recent version. \
 See https://github.com/cpm-cmake/CPM.cmake for more information."
@@ -69,10 +73,11 @@ See https://github.com/cpm-cmake/CPM.cmake for more information."
 endif()
 
 if(CURRENT_CPM_VERSION MATCHES "development-version")
-  message(WARNING "${CPM_INDENT} Your project is using an unstable development version of CPM.cmake. \
+  message(
+    WARNING "${CPM_INDENT} Your project is using an unstable development version of CPM.cmake. \
 Please update to a recent release if possible. \
 See https://github.com/cpm-cmake/CPM.cmake for details."
-          )
+  )
 endif()
 
 set_property(GLOBAL PROPERTY CPM_INITIALIZED true)
@@ -233,14 +238,6 @@ function(cpm_package_name_and_ver_from_url url outName outVer)
   endif()
 endfunction()
 
-# Initialize logging prefix
-if(NOT CPM_INDENT)
-  set(CPM_INDENT
-      "CPM:"
-      CACHE INTERNAL ""
-  )
-endif()
-
 function(cpm_find_package NAME VERSION)
   string(REPLACE " " ";" EXTRA_ARGS "${ARGN}")
   find_package(${NAME} ${VERSION} ${EXTRA_ARGS} QUIET)
@@ -318,8 +315,8 @@ function(cpm_check_if_package_already_added CPM_ARGS_NAME CPM_ARGS_VERSION)
     CPMGetPackageVersion(${CPM_ARGS_NAME} CPM_PACKAGE_VERSION)
     if("${CPM_PACKAGE_VERSION}" VERSION_LESS "${CPM_ARGS_VERSION}")
       message(
-              WARNING
-              "${CPM_INDENT} Requires a newer version of ${CPM_ARGS_NAME} (${CPM_ARGS_VERSION}) than currently included (${CPM_PACKAGE_VERSION})."
+        WARNING
+          "${CPM_INDENT} Requires a newer version of ${CPM_ARGS_NAME} (${CPM_ARGS_VERSION}) than currently included (${CPM_PACKAGE_VERSION})."
       )
     endif()
     cpm_get_fetch_properties(${CPM_ARGS_NAME})
@@ -431,9 +428,9 @@ function(cpm_check_git_working_dir_is_clean repoPath gitTag isClean)
     # not supposed to happen, assume clean anyway
     message(WARNING "${CPM_INDENT} Calling git status on folder ${repoPath} failed")
     set(${isClean}
-            TRUE
-            PARENT_SCOPE
-            )
+        TRUE
+        PARENT_SCOPE
+    )
     return()
   endif()
 
@@ -609,8 +606,8 @@ function(CPMAddPackage)
 
   if(NOT DEFINED CPM_ARGS_NAME)
     message(
-            FATAL_ERROR
-            "${CPM_INDENT} 'NAME' was not provided and couldn't be automatically inferred for package added with arguments: '${ARGN}'"
+      FATAL_ERROR
+        "${CPM_INDENT} 'NAME' was not provided and couldn't be automatically inferred for package added with arguments: '${ARGN}'"
     )
   endif()
 
@@ -659,8 +656,8 @@ function(CPMAddPackage)
 
     if(CPM_LOCAL_PACKAGES_ONLY)
       message(
-              SEND_ERROR
-              "${CPM_INDENT} ${CPM_ARGS_NAME} not found via find_package(${CPM_ARGS_NAME} ${CPM_ARGS_VERSION})"
+        SEND_ERROR
+          "${CPM_INDENT} ${CPM_ARGS_NAME} not found via find_package(${CPM_ARGS_NAME} ${CPM_ARGS_VERSION})"
       )
     endif()
   endif()
@@ -726,7 +723,9 @@ function(CPMAddPackage)
         # warn if cache has been changed since checkout
         cpm_check_git_working_dir_is_clean(${download_directory} ${CPM_ARGS_GIT_TAG} IS_CLEAN)
         if(NOT ${IS_CLEAN})
-          message(WARNING "${CPM_INDENT} Cache for ${CPM_ARGS_NAME} (${download_directory}) is dirty")
+          message(
+            WARNING "${CPM_INDENT} Cache for ${CPM_ARGS_NAME} (${download_directory}) is dirty"
+          )
         endif()
       endif()
 
@@ -762,28 +761,28 @@ function(CPMAddPackage)
 
   cpm_create_module_file(${CPM_ARGS_NAME} "CPMAddPackage(\"${ARGN}\")")
 
-  if (CPM_PACKAGE_LOCK_ENABLED)
-    if ((CPM_ARGS_VERSION AND NOT CPM_ARGS_SOURCE_DIR) OR CPM_INCLUDE_ALL_IN_PACKAGE_LOCK)
+  if(CPM_PACKAGE_LOCK_ENABLED)
+    if((CPM_ARGS_VERSION AND NOT CPM_ARGS_SOURCE_DIR) OR CPM_INCLUDE_ALL_IN_PACKAGE_LOCK)
       cpm_add_to_package_lock(${CPM_ARGS_NAME} "${ARGN}")
-    elseif (CPM_ARGS_SOURCE_DIR)
+    elseif(CPM_ARGS_SOURCE_DIR)
       cpm_add_comment_to_package_lock(${CPM_ARGS_NAME} "local directory")
-    else ()
+    else()
       cpm_add_comment_to_package_lock(${CPM_ARGS_NAME} "${ARGN}")
-    endif ()
-  endif ()
+    endif()
+  endif()
 
   cpm_message(
-          STATUS "${CPM_INDENT} Adding package ${CPM_ARGS_NAME}@${CPM_ARGS_VERSION} (${PACKAGE_INFO})"
+    STATUS "${CPM_INDENT} Adding package ${CPM_ARGS_NAME}@${CPM_ARGS_VERSION} (${PACKAGE_INFO})"
   )
 
-  if (NOT CPM_SKIP_FETCH)
+  if(NOT CPM_SKIP_FETCH)
     cpm_declare_fetch(
-            "${CPM_ARGS_NAME}" "${CPM_ARGS_VERSION}" "${PACKAGE_INFO}" "${CPM_ARGS_UNPARSED_ARGUMENTS}"
+      "${CPM_ARGS_NAME}" "${CPM_ARGS_VERSION}" "${PACKAGE_INFO}" "${CPM_ARGS_UNPARSED_ARGUMENTS}"
     )
     cpm_fetch_package("${CPM_ARGS_NAME}" populated)
-    if (${populated})
+    if(${populated})
       cpm_add_subdirectory(
-              "${CPM_ARGS_NAME}" "${DOWNLOAD_ONLY}"
+        "${CPM_ARGS_NAME}" "${DOWNLOAD_ONLY}"
         "${${CPM_ARGS_NAME}_SOURCE_DIR}/${CPM_ARGS_SOURCE_SUBDIR}" "${${CPM_ARGS_NAME}_BINARY_DIR}"
         "${CPM_ARGS_EXCLUDE_FROM_ALL}" "${CPM_ARGS_OPTIONS}"
       )


### PR DESCRIPTION
This PR add an helper function only when `message(STATUS ...)` as the other are `backtracing` and adding the helper function would add on stack.

It should fix #328 #342 with a few line of code.

Default behaviour : 
![Screenshot_20221123_112206](https://user-images.githubusercontent.com/8627746/203523177-e15740ef-6de9-4f12-a916-51635b66d202.png)
 
Possible output redefining the `cpm_message` : 
![Screenshot_20221123_111315](https://user-images.githubusercontent.com/8627746/203523301-4adaec88-0177-4ef3-be14-88c1bfce8829.png)
