### PR TITLE
get_cpm: Recover from failed download

### DIFF
--- a/cmake/get_cpm.cmake
+++ b/cmake/get_cpm.cmake
@@ -10,12 +10,23 @@ endif()
 
 # Expand relative path. This is important if the provided path contains a tilde (~)
 get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
-if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
+
+function(dl_cpm)
   message(STATUS "Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
   file(DOWNLOAD
        https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
        ${CPM_DOWNLOAD_LOCATION}
   )
+endfunction()
+
+if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
+  dl_cpm()
+else()
+  # resume download if it previously failed
+  file(READ ${CPM_DOWNLOAD_LOCATION} check)
+  if("${check}" STREQUAL "")
+    dl_cpm()
+  endif()
 endif()
 
 include(${CPM_DOWNLOAD_LOCATION})

--- a/cmake/get_cpm.cmake
+++ b/cmake/get_cpm.cmake
@@ -11,7 +11,7 @@ endif()
 # Expand relative path. This is important if the provided path contains a tilde (~)
 get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
 
-function(dl_cpm)
+function(download_cpm)
   message(STATUS "Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
   file(DOWNLOAD
        https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
@@ -20,12 +20,12 @@ function(dl_cpm)
 endfunction()
 
 if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
-  dl_cpm()
+  download_cpm()
 else()
   # resume download if it previously failed
   file(READ ${CPM_DOWNLOAD_LOCATION} check)
   if("${check}" STREQUAL "")
-    dl_cpm()
+    download_cpm()
   endif()
 endif()
 


### PR DESCRIPTION
If the download fails during the cmake config step an empty `CPM_<version>.cmake` file is created.
So far the script only checks the files existence, so there is no second try until the empty file is deleted manually.

This adds a check if the file is empty
and resumes the download on next config if it is.