### PR TITLE
Update example dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ include(cmake/CPM.cmake)
 
 CPMAddPackage("gh:fmtlib/fmt#7.1.3")
 CPMAddPackage("gh:nlohmann/json@3.10.5")
-CPMAddPackage("gh:catchorg/Catch2@2.5.0")
+CPMAddPackage("gh:catchorg/Catch2@3.2.1")
 
 # link dependencies
-target_link_libraries(main fmt::fmt nlohmann_json::nlohmann_json Catch2::Catch2)
+target_link_libraries(main fmt::fmt nlohmann_json::nlohmann_json Catch2::Catch2WithMain)
 ```
 
 See the [examples directory](https://github.com/cpm-cmake/CPM.cmake/tree/master/examples) for complete examples with source code and check [below](#snippets) or in the [wiki](https://github.com/cpm-cmake/CPM.cmake/wiki/More-Snippets) for example snippets.
@@ -353,9 +353,9 @@ CPMAddPackage(
 # using `CPM_SOURCE_CACHE` is strongly recommended
 CPMAddPackage(
   NAME Boost
-  VERSION 1.77.0
+  VERSION 1.81.0
   GITHUB_REPOSITORY "boostorg/boost"
-  GIT_TAG "boost-1.77.0"
+  GIT_TAG "boost-1.81.0"
 )
 ```
 

--- a/examples/benchmark/CMakeLists.txt
+++ b/examples/benchmark/CMakeLists.txt
@@ -11,7 +11,7 @@ CPMAddPackage("gh:cpm-cmake/testpack-fibonacci@2.0")
 CPMAddPackage(
   NAME benchmark
   GITHUB_REPOSITORY google/benchmark
-  VERSION 1.5.2
+  VERSION 1.7.1
   OPTIONS "BENCHMARK_ENABLE_TESTING Off"
 )
 

--- a/examples/boost/CMakeLists.txt
+++ b/examples/boost/CMakeLists.txt
@@ -13,9 +13,9 @@ include(../../cmake/CPM.cmake)
 
 CPMAddPackage(
   NAME Boost
-  VERSION 1.77.0
+  VERSION 1.81.0
   GITHUB_REPOSITORY "boostorg/boost"
-  GIT_TAG "boost-1.77.0"
+  GIT_TAG "boost-1.81.0"
 )
 
 target_link_libraries(CPMExampleBoost PRIVATE Boost::asio)

--- a/examples/catch2/CMakeLists.txt
+++ b/examples/catch2/CMakeLists.txt
@@ -7,12 +7,12 @@ project(CPMExampleCatch2)
 include(../../cmake/CPM.cmake)
 
 CPMAddPackage("gh:cpm-cmake/testpack-fibonacci@2.0")
-CPMAddPackage("gh:catchorg/Catch2@2.13.4")
+CPMAddPackage("gh:catchorg/Catch2@3.2.1")
 
 # ---- Create binary ----
 
 add_executable(CPMExampleCatch2 main.cpp)
-target_link_libraries(CPMExampleCatch2 fibonacci Catch2)
+target_link_libraries(CPMExampleCatch2 fibonacci Catch2::Catch2WithMain)
 target_compile_features(CPMExampleCatch2 PRIVATE cxx_std_17)
 
 # ---- Enable testing ----

--- a/examples/catch2/main.cpp
+++ b/examples/catch2/main.cpp
@@ -1,8 +1,6 @@
-#define CATCH_CONFIG_MAIN
-
 #include <fibonacci.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 TEST_CASE("fibonacci") {
   REQUIRE(fibonacci(0) == 0);

--- a/examples/doctest/CMakeLists.txt
+++ b/examples/doctest/CMakeLists.txt
@@ -7,7 +7,7 @@ project(CPMExampleDoctest)
 include(../../cmake/CPM.cmake)
 
 CPMAddPackage("gh:cpm-cmake/testpack-fibonacci@2.0")
-CPMAddPackage("gh:onqtam/doctest#2.4.5")
+CPMAddPackage("gh:onqtam/doctest@2.4.9")
 
 # ---- Create binary ----
 

--- a/examples/gtest/CMakeLists.txt
+++ b/examples/gtest/CMakeLists.txt
@@ -11,8 +11,8 @@ CPMAddPackage("gh:cpm-cmake/testpack-fibonacci@2.0")
 CPMAddPackage(
   NAME googletest
   GITHUB_REPOSITORY google/googletest
-  GIT_TAG release-1.10.0
-  VERSION 1.10.0
+  GIT_TAG release-1.12.1
+  VERSION 1.12.1
   OPTIONS "INSTALL_GTEST OFF" "gtest_force_shared_crt"
 )
 

--- a/examples/sol2/CMakeLists.txt
+++ b/examples/sol2/CMakeLists.txt
@@ -15,29 +15,16 @@ CPMAddPackage(
 
 if(lua_ADDED)
   # lua has no CMakeLists, so we create our own target
-
   file(GLOB lua_sources ${lua_SOURCE_DIR}/*.c)
   list(REMOVE_ITEM lua_sources "${lua_SOURCE_DIR}/lua.c" "${lua_SOURCE_DIR}/luac.c")
   add_library(lua STATIC ${lua_sources})
-
   target_include_directories(lua SYSTEM PUBLIC $<BUILD_INTERFACE:${lua_SOURCE_DIR}>)
 endif()
 
-CPMAddPackage(
-  NAME sol2
-  URL https://github.com/ThePhD/sol2/archive/v3.0.2.zip
-  VERSION 3.0.2
-  DOWNLOAD_ONLY YES
-)
-
-if(sol2_ADDED)
-  add_library(sol2 INTERFACE IMPORTED)
-  target_include_directories(sol2 SYSTEM INTERFACE ${sol2_SOURCE_DIR}/include)
-  target_link_libraries(sol2 INTERFACE lua)
-endif()
+CPMAddPackage("gh:ThePhD/sol2@3.3.0")
 
 # ---- Executable ----
 
 add_executable(CPMSol2Example main.cpp)
 target_compile_features(CPMSol2Example PRIVATE cxx_std_17)
-target_link_libraries(CPMSol2Example sol2)
+target_link_libraries(CPMSol2Example sol2 lua)


### PR DESCRIPTION
This PR updates versions of dependencies used in examples for better compatibility with new hardware and CMake versions.

## Motivation

It seems that the GitHub runner image `ubuntu-latest` was updated to use recent versions C++ build tools, resulting in some errors from various dependencies. These seem to already be addressed in more recent versions so we can simply update the dependencies to be compatible with the newest GitHub runners.

Might fix issues currently blocking  #427 from continuing.
