### PR TITLE
Add SYSTEM option

### DIFF
--- a/.cmake-format
+++ b/.cmake-format
@@ -34,6 +34,7 @@ parse:
         HTTP_USERNAME: 1
         HTTP_PASSWORD: 1
         EXCLUDE_FROM_ALL: 1
+        SYSTEM: 1
         SOURCE_SUBDIR: 1
         OPTIONS: +
     cpmfindpackage:

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -12,7 +12,7 @@ jobs:
   gcc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: build all
         env:
           CC: gcc
@@ -22,7 +22,7 @@ jobs:
   clang:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: build all
         env:
           CC: clang

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Publish CPM.cmake
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Set CPM version by tag
         run: |

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -14,7 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v1.13
+      with:
+        cmake-version: '3.25.x'
     
     - name: Install format dependencies
       run: pip3 install clang-format==14.0.6 cmake_format==0.6.11 pyyaml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: clone
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1.13

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,11 @@ jobs:
       - name: clone
         uses: actions/checkout@v2
 
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v1.13
+        with:
+          cmake-version: '3.25.x'
+
       - name: unit tests
         run: |
           cmake -Stest -Bbuild/test

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ On the other hand, if `VERSION` hasn't been explicitly specified, CPM can automa
 
 If an additional optional parameter `EXCLUDE_FROM_ALL` is set to a truthy value, then any targets defined inside the dependency won't be built by default. See the [CMake docs](https://cmake.org/cmake/help/latest/prop_tgt/EXCLUDE_FROM_ALL.html) for details.
 
+If an additional optional parameter `SYSTEM` is set to a truthy value, then any headers included from targets defined inside the dependency will be treated as system headers. See the [CMake docs](https://cmake.org/cmake/help/latest/prop_dir/SYSTEM.html#prop_dir:SYSTEM) for details.
+
+
 A single-argument compact syntax is also supported:
 
 ```cmake

--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ On the other hand, if `VERSION` hasn't been explicitly specified, CPM can automa
 
 If an additional optional parameter `EXCLUDE_FROM_ALL` is set to a truthy value, then any targets defined inside the dependency won't be built by default. See the [CMake docs](https://cmake.org/cmake/help/latest/prop_tgt/EXCLUDE_FROM_ALL.html) for details.
 
-If an additional optional parameter `SYSTEM` is set to a truthy value, then any headers included from targets defined inside the dependency will be treated as system headers. See the [CMake docs](https://cmake.org/cmake/help/latest/prop_dir/SYSTEM.html#prop_dir:SYSTEM) for details.
-
+If an additional optional parameter `SYSTEM` is set to a truthy value, the SYSTEM directory property of the subdirectory added will be set to true.
+See the [add_subdirectory ](https://cmake.org/cmake/help/latest/command/add_subdirectory.html?highlight=add_subdirectory)
+and [SYSTEM](https://cmake.org/cmake/help/latest/prop_tgt/SYSTEM.html#prop_tgt:SYSTEM) target property for details.
 
 A single-argument compact syntax is also supported:
 

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -627,6 +627,7 @@ function(CPMAddPackage)
       NAME "${CPM_ARGS_NAME}"
       SOURCE_DIR "${PACKAGE_SOURCE}"
       EXCLUDE_FROM_ALL "${CPM_ARGS_EXCLUDE_FROM_ALL}"
+      SYSTEM "${CPM_ARGS_SYSTEM}"
       OPTIONS "${CPM_ARGS_OPTIONS}"
       SOURCE_SUBDIR "${CPM_ARGS_SOURCE_SUBDIR}"
       DOWNLOAD_ONLY "${DOWNLOAD_ONLY}"
@@ -956,14 +957,13 @@ function(
 )
 
   if(NOT DOWNLOAD_ONLY AND EXISTS ${SOURCE_DIR}/CMakeLists.txt)
+    set(addSubdirectoryExtraArgs "")
     if(EXCLUDE)
-      set(addSubdirectoryExtraArgs EXCLUDE_FROM_ALL)
-    else()
-      set(addSubdirectoryExtraArgs "")
+      list(APPEND addSubdirectoryExtraArgs EXCLUDE_FROM_ALL)
     endif()
     if("${SYSTEM}" AND "${CMAKE_VERSION}" VERSION_GREATER_EQUAL "3.25")
       # https://cmake.org/cmake/help/latest/prop_dir/SYSTEM.html#prop_dir:SYSTEM
-      set(addSubdirectoryExtraArgs ${addSubdirectoryExtraArgs} SYSTEM)
+      list(APPEND addSubdirectoryExtraArgs SYSTEM)
     endif()
     if(OPTIONS)
       foreach(OPTION ${OPTIONS})

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -513,7 +513,7 @@ function(CPMAddPackage)
   if(argnLength EQUAL 1)
     cpm_parse_add_package_single_arg("${ARGN}" ARGN)
 
-    # The shorthand syntax implies EXCLUDE_FROM_ALL and SYSTEM
+    # The shorthand syntax implies EXCLUDE_FROM_ALL
     set(ARGN "${ARGN};EXCLUDE_FROM_ALL;YES;")
   endif()
 

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -513,8 +513,8 @@ function(CPMAddPackage)
   if(argnLength EQUAL 1)
     cpm_parse_add_package_single_arg("${ARGN}" ARGN)
 
-    # The shorthand syntax implies EXCLUDE_FROM_ALL
-    set(ARGN "${ARGN};EXCLUDE_FROM_ALL;YES")
+    # The shorthand syntax implies EXCLUDE_FROM_ALL and SYSTEM
+    set(ARGN "${ARGN};EXCLUDE_FROM_ALL;YES;")
   endif()
 
   set(oneValueArgs
@@ -531,6 +531,7 @@ function(CPMAddPackage)
       DOWNLOAD_COMMAND
       FIND_PACKAGE_ARGUMENTS
       NO_CACHE
+      SYSTEM
       GIT_SHALLOW
       EXCLUDE_FROM_ALL
       SOURCE_SUBDIR
@@ -733,9 +734,13 @@ function(CPMAddPackage)
       endif()
 
       cpm_add_subdirectory(
-        "${CPM_ARGS_NAME}" "${DOWNLOAD_ONLY}"
-        "${${CPM_ARGS_NAME}_SOURCE_DIR}/${CPM_ARGS_SOURCE_SUBDIR}" "${${CPM_ARGS_NAME}_BINARY_DIR}"
-        "${CPM_ARGS_EXCLUDE_FROM_ALL}" "${CPM_ARGS_OPTIONS}"
+        "${CPM_ARGS_NAME}"
+        "${DOWNLOAD_ONLY}"
+        "${${CPM_ARGS_NAME}_SOURCE_DIR}/${CPM_ARGS_SOURCE_SUBDIR}"
+        "${${CPM_ARGS_NAME}_BINARY_DIR}"
+        "${CPM_ARGS_EXCLUDE_FROM_ALL}"
+        "${CPM_ARGS_SYSTEM}"
+        "${CPM_ARGS_OPTIONS}"
       )
       set(PACKAGE_INFO "${PACKAGE_INFO} at ${download_directory}")
 
@@ -785,9 +790,13 @@ function(CPMAddPackage)
     cpm_fetch_package("${CPM_ARGS_NAME}" populated)
     if(${populated})
       cpm_add_subdirectory(
-        "${CPM_ARGS_NAME}" "${DOWNLOAD_ONLY}"
-        "${${CPM_ARGS_NAME}_SOURCE_DIR}/${CPM_ARGS_SOURCE_SUBDIR}" "${${CPM_ARGS_NAME}_BINARY_DIR}"
-        "${CPM_ARGS_EXCLUDE_FROM_ALL}" "${CPM_ARGS_OPTIONS}"
+        "${CPM_ARGS_NAME}"
+        "${DOWNLOAD_ONLY}"
+        "${${CPM_ARGS_NAME}_SOURCE_DIR}/${CPM_ARGS_SOURCE_SUBDIR}"
+        "${${CPM_ARGS_NAME}_BINARY_DIR}"
+        "${CPM_ARGS_EXCLUDE_FROM_ALL}"
+        "${CPM_ARGS_SYSTEM}"
+        "${CPM_ARGS_OPTIONS}"
       )
     endif()
     cpm_get_fetch_properties("${CPM_ARGS_NAME}")
@@ -942,15 +951,17 @@ function(
   SOURCE_DIR
   BINARY_DIR
   EXCLUDE
+  SYSTEM
   OPTIONS
 )
+
   if(NOT DOWNLOAD_ONLY AND EXISTS ${SOURCE_DIR}/CMakeLists.txt)
     if(EXCLUDE)
       set(addSubdirectoryExtraArgs EXCLUDE_FROM_ALL)
     else()
       set(addSubdirectoryExtraArgs "")
     endif()
-    if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25")
+    if("${SYSTEM}" AND "${CMAKE_VERSION}" VERSION_GREATER_EQUAL "3.25")
       # https://cmake.org/cmake/help/latest/prop_dir/SYSTEM.html#prop_dir:SYSTEM
       set(addSubdirectoryExtraArgs ${addSubdirectoryExtraArgs} SYSTEM)
     endif()
@@ -1083,6 +1094,7 @@ function(cpm_prettify_package_arguments OUT_VAR IS_IN_COMMENT)
       DOWNLOAD_COMMAND
       FIND_PACKAGE_ARGUMENTS
       NO_CACHE
+      SYSTEM
       GIT_SHALLOW
   )
   set(multiValueArgs OPTIONS)

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -950,6 +950,10 @@ function(
     else()
       set(addSubdirectoryExtraArgs "")
     endif()
+    if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25")
+      # https://cmake.org/cmake/help/latest/prop_dir/SYSTEM.html#prop_dir:SYSTEM
+      set(addSubdirectoryExtraArgs ${addSubdirectoryExtraArgs} SYSTEM)
+    endif()
     if(OPTIONS)
       foreach(OPTION ${OPTIONS})
         cpm_parse_option("${OPTION}")

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -513,8 +513,8 @@ function(CPMAddPackage)
   if(argnLength EQUAL 1)
     cpm_parse_add_package_single_arg("${ARGN}" ARGN)
 
-    # The shorthand syntax implies EXCLUDE_FROM_ALL
-    set(ARGN "${ARGN};EXCLUDE_FROM_ALL;YES;")
+    # The shorthand syntax implies EXCLUDE_FROM_ALL and SYSTEM
+    set(ARGN "${ARGN};EXCLUDE_FROM_ALL;YES;SYSTEM;YES;")
   endif()
 
   set(oneValueArgs

--- a/test/integration/lib.rb
+++ b/test/integration/lib.rb
@@ -157,6 +157,11 @@ class IntegrationTest < Test::Unit::TestCase
     assert_block(msg) { res.status.success? }
   end
 
+  def assert_failure(res)
+    msg = build_message(nil, "command status was expected to be a failure, but succeeded")
+    assert_block(msg) { !res.status.success? }
+  end
+
   def assert_same_path(a, b)
     msg = build_message(nil, "<?> expected but was\n<?>", a, b)
     assert_block(msg) { File.identical? a, b }

--- a/test/integration/test_system_warnings.rb
+++ b/test/integration/test_system_warnings.rb
@@ -8,13 +8,13 @@ class SystemWarnings < IntegrationTest
       CPMAddPackage(
         NAME Adder
         GITHUB_REPOSITORY cpm-cmake/testpack-adder
-        GIT_TAG 8805960927ef97960dfc7d121760c8201e12d906
+        GIT_TAG cf22d3e48d368ff268a98cfc37d4b3471b4b31c9
         SYSTEM YES
       )
       # all packages using `adder` will error on warnings
       target_compile_options(adder INTERFACE
-        $<$<CXX_COMPILER_ID:MSVC>:/we4033 /we4716 /we4715 /WX>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wreturn-type -Werror>
+        $<$<CXX_COMPILER_ID:MSVC>:/Wall /WX>
+        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Werror>
       )
     PACK
 
@@ -29,13 +29,13 @@ class SystemWarnings < IntegrationTest
       CPMAddPackage(
         NAME Adder
         GITHUB_REPOSITORY cpm-cmake/testpack-adder
-        GIT_TAG 8805960927ef97960dfc7d121760c8201e12d906
+        GIT_TAG cf22d3e48d368ff268a98cfc37d4b3471b4b31c9
         SYSTEM NO
       )
       # all packages using `adder` will error on warnings
       target_compile_options(adder INTERFACE
-        $<$<CXX_COMPILER_ID:MSVC>:/we4033 /we4716 /we4715 /WX>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wreturn-type -Werror>
+        $<$<CXX_COMPILER_ID:MSVC>:/Wall /WX>
+        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Werror>
       )
     PACK
 

--- a/test/integration/test_system_warnings.rb
+++ b/test/integration/test_system_warnings.rb
@@ -1,8 +1,8 @@
 require_relative './lib'
 
 class SystemWarnings < IntegrationTest
+  
   def test_dependency_added_using_system
-
     for use_system in [true, false] do
       prj = make_project name: use_system ? "system" : "no_system", from_template: 'using-adder'
       prj.create_lists_from_default_template package: <<~PACK
@@ -27,6 +27,22 @@ class SystemWarnings < IntegrationTest
         assert_failure prj.build
       end
     end
+  end
+  
+  def test_dependency_added_implicitly_using_system
+    prj = make_project from_template: 'using-adder'
+    prj.create_lists_from_default_template package: <<~PACK
+      # this commit has a warning in a public header
+      CPMAddPackage("gh:cpm-cmake/testpack-adder@1.0.1-warnings")
+      # all packages using `adder` will error on warnings
+      target_compile_options(adder INTERFACE
+        $<$<CXX_COMPILER_ID:MSVC>:/Wall /WX>
+        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Werror>
+      )
+    PACK
+
+    assert_success prj.configure
+    assert_success prj.build
   end
 
 end

--- a/test/integration/test_system_warnings.rb
+++ b/test/integration/test_system_warnings.rb
@@ -13,8 +13,8 @@ class SystemWarnings < IntegrationTest
       )
       # all packages using `adder` will error on warnings
       target_compile_options(adder INTERFACE
-        $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
+        $<$<CXX_COMPILER_ID:MSVC>:/we4033 /we4716 /we4715 /WX>
+        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wreturn-type -Werror>
       )
     PACK
 
@@ -34,8 +34,8 @@ class SystemWarnings < IntegrationTest
       )
       # all packages using `adder` will error on warnings
       target_compile_options(adder INTERFACE
-        $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
+        $<$<CXX_COMPILER_ID:MSVC>:/we4033 /we4716 /we4715 /WX>
+        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wreturn-type -Werror>
       )
     PACK
 

--- a/test/integration/test_system_warnings.rb
+++ b/test/integration/test_system_warnings.rb
@@ -1,0 +1,18 @@
+require_relative './lib'
+
+class SystemWarnings < IntegrationTest
+  def test_add_dependency_cpm_and_fetchcontent
+    prj = make_project from_template: 'using-adder'
+    prj.create_lists_from_default_template package: <<~PACK
+      # this commit has a warning in a public header
+      CPMAddPackage("gh:cpm-cmake/testpack-adder#3046a5837ffc6a304c4a60258d39d6d2a4255548")
+      # all packages using `adder` will error on warnings
+      target_compile_options(adder INTERFACE "-Werror")
+    PACK
+
+    assert_success prj.configure
+    # as the dependency's headers are treated as system headers, 
+    # the project should build without errors 
+    assert_success prj.build
+  end
+end

--- a/test/integration/test_system_warnings.rb
+++ b/test/integration/test_system_warnings.rb
@@ -2,45 +2,31 @@ require_relative './lib'
 
 class SystemWarnings < IntegrationTest
   def test_dependency_added_using_system
-    prj = make_project from_template: 'using-adder'
-    prj.create_lists_from_default_template package: <<~PACK
-      # this commit has a warning in a public header
-      CPMAddPackage(
-        NAME Adder
-        GITHUB_REPOSITORY cpm-cmake/testpack-adder
-        GIT_TAG cf22d3e48d368ff268a98cfc37d4b3471b4b31c9
-        SYSTEM YES
-      )
-      # all packages using `adder` will error on warnings
-      target_compile_options(adder INTERFACE
-        $<$<CXX_COMPILER_ID:MSVC>:/Wall /WX>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Werror>
-      )
-    PACK
 
-    assert_success prj.configure
-    assert_success prj.build
-  end
+    for use_system in [true, false] do
+      prj = make_project name: use_system ? "system" : "no_system", from_template: 'using-adder'
+      prj.create_lists_from_default_template package: <<~PACK
+        # this commit has a warning in a public header
+        CPMAddPackage(
+          NAME Adder
+          GITHUB_REPOSITORY cpm-cmake/testpack-adder
+          GIT_TAG v1.0.1-warnings
+          SYSTEM #{use_system ? "YES" : "NO"}
+        )
+        # all packages using `adder` will error on warnings
+        target_compile_options(adder INTERFACE
+          $<$<CXX_COMPILER_ID:MSVC>:/Wall /WX>
+          $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Werror>
+        )
+      PACK
 
-  def test_dependency_added_not_using_system
-    prj = make_project from_template: 'using-adder'
-    prj.create_lists_from_default_template package: <<~PACK
-      # this commit has a warning in a public header
-      CPMAddPackage(
-        NAME Adder
-        GITHUB_REPOSITORY cpm-cmake/testpack-adder
-        GIT_TAG cf22d3e48d368ff268a98cfc37d4b3471b4b31c9
-        SYSTEM NO
-      )
-      # all packages using `adder` will error on warnings
-      target_compile_options(adder INTERFACE
-        $<$<CXX_COMPILER_ID:MSVC>:/Wall /WX>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Werror>
-      )
-    PACK
-
-    assert_success prj.configure
-    assert_failure prj.build
+      assert_success prj.configure
+      if use_system
+        assert_success prj.build
+      else
+        assert_failure prj.build
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Adds experimental support for the [SYSTEM](https://cmake.org/cmake/help/latest/prop_dir/SYSTEM.html#prop_dir:SYSTEM) property as an opt-in option for `CPMAddPackage`.

## Todo

- [x] Document the option in the Readme

## Open Questions

- Should it be on by default for the single argument syntax?
- As we now control the CMake version in the tests, should we also test legacy versions for backwards compatibility?

Something noteworthy from the [CMake docs](https://cmake.org/cmake/help/latest/command/target_include_directories.html) is that it changes the include search order.

> Additionally, system include directories are searched after normal include directories regardless of the order specified.

Closes #377 
