### PR TITLE
Add CMake version as workflow matrix parameter

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-latest, windows-2022, macos-latest]
         # we want to ensure compatibility with a recent CMake version as well as the lowest officially supported
         # legacy version that we define as the default version of the second-latest Ubuntu LTS release currently available
-        cmake_version: ['3.16.x', '3.25.x']
+        cmake_version: ['3.16.3', '3.25.1']
 
     steps:
       - name: clone

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,3 +41,4 @@ jobs:
         run: ruby test/integration/runner.rb
         env:
           CPM_INTEGRATION_TEST_DIR: ./build/integration
+          CMAKE_VERSION: ${{ matrix.cmake_version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,9 @@ jobs:
         # we need at least ruby 2.7 for the tests
         # instead of dealing with installing a modern version of ruby on 2019, we'll just use windows-2022 here
         os: [ubuntu-latest, windows-2022, macos-latest]
+        # we want to ensure compatibility with a recent CMake version as well as the lowest officially supported
+        # legacy version that we define as the default version of the second-latest Ubuntu LTS release currently available
+        cmake_version: ['3.16.x', '3.25.x']
 
     steps:
       - name: clone
@@ -25,12 +28,14 @@ jobs:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1.13
         with:
-          cmake-version: '3.25.x'
+          cmake-version: ${{ matrix.cmake_version }}
 
       - name: unit tests
         run: |
           cmake -Stest -Bbuild/test
           cmake --build build/test --target test-verbose
+        env:
+          CMAKE_VERSION: ${{ matrix.cmake_version }}
 
       - name: integration tests
         run: ruby test/integration/runner.rb

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,10 @@ jobs:
         # we want to ensure compatibility with a recent CMake version as well as the lowest officially supported
         # legacy version that we define as the default version of the second-latest Ubuntu LTS release currently available
         cmake_version: ['3.16.3', '3.25.1']
+        exclude:
+          # there seems to be an issue with CMake 3.16 not finding a C++ compiler on windows-2022 
+          - os: windows-2022
+            cmake_version: '3.16.3'
 
     steps:
       - name: clone

--- a/test/integration/test_system_warnings.rb
+++ b/test/integration/test_system_warnings.rb
@@ -2,6 +2,11 @@ require_relative './lib'
 
 class SystemWarnings < IntegrationTest
   
+  def setup
+    # system is only supported for CMake >= 3.25 
+    @system_supported = (!ENV['CMAKE_VERSION']) || (Gem::Version.new(ENV['CMAKE_VERSION']) >= Gem::Version.new('3.25'))
+  end
+
   def test_dependency_added_using_system
     for use_system in [true, false] do
       prj = make_project name: use_system ? "system" : "no_system", from_template: 'using-adder'
@@ -21,7 +26,7 @@ class SystemWarnings < IntegrationTest
       PACK
 
       assert_success prj.configure
-      if use_system
+      if use_system and @system_supported
         assert_success prj.build
       else
         assert_failure prj.build
@@ -42,7 +47,11 @@ class SystemWarnings < IntegrationTest
     PACK
 
     assert_success prj.configure
-    assert_success prj.build
+    if @system_supported
+      assert_success prj.build
+    else
+      assert_failure prj.build
+    end
   end
 
 end


### PR DESCRIPTION
As discussed in #449, this adds support for testing a legacy CMake version in the GitHub workflow.