### PR TITLE
Add AALTITOAD to "Built with CPM.cmake"

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,14 @@ If you know others, feel free to add them here through a PR.
         <p align="center"><b>JNGL - easy to use cross-platform 2D game library</b></p>
       </a>
     </td>
-    <td/>
+    <td>
+      <a href="https://github.com/sillydan1/aaltitoad">
+        <p align="center">
+          <img src="https://github.com/sillydan1/aaltitoad/raw/v1.1.0/.github/resources/logo/toad_only.svg" alt="aaltitoad" width="100pt" />
+        </p>
+        <p align="center"><b>AALTITOAD - verifier and simulator for Tick Tock Automata</b></p>
+      </a>
+    </td>
     <td/>
   </tr>
 </table>


### PR DESCRIPTION
I'm using CPM to manage (almost) all of my dependencies for my formal verification engine and associated projects. This enabled me to extract all of the individual libraries into separate repositories so they can be reused for other projects.

It's a small project, but I hope you guys don't mind having me on the list anyway.