### PR TITLE
Fix DOWNLOAD_COMMAND with multi-token string

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -528,7 +528,6 @@ function(CPMAddPackage)
       BITBUCKET_REPOSITORY
       GIT_REPOSITORY
       SOURCE_DIR
-      DOWNLOAD_COMMAND
       FIND_PACKAGE_ARGUMENTS
       NO_CACHE
       SYSTEM
@@ -537,7 +536,7 @@ function(CPMAddPackage)
       SOURCE_SUBDIR
   )
 
-  set(multiValueArgs URL OPTIONS)
+  set(multiValueArgs URL OPTIONS DOWNLOAD_COMMAND)
 
   cmake_parse_arguments(CPM_ARGS "" "${oneValueArgs}" "${multiValueArgs}" "${ARGN}")
 
@@ -1098,13 +1097,12 @@ function(cpm_prettify_package_arguments OUT_VAR IS_IN_COMMENT)
       GITLAB_REPOSITORY
       GIT_REPOSITORY
       SOURCE_DIR
-      DOWNLOAD_COMMAND
       FIND_PACKAGE_ARGUMENTS
       NO_CACHE
       SYSTEM
       GIT_SHALLOW
   )
-  set(multiValueArgs OPTIONS)
+  set(multiValueArgs URL OPTIONS DOWNLOAD_COMMAND)
   cmake_parse_arguments(CPM_ARGS "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
   foreach(oneArgName ${oneValueArgs})

--- a/test/integration/test_download_command.rb
+++ b/test/integration/test_download_command.rb
@@ -1,0 +1,25 @@
+require_relative './lib'
+
+# Tests using a multi-argumenet download command to fetch a dependency
+
+class DownloadCommand < IntegrationTest
+
+  def test_fetch_dependency_using_download_command
+    prj = make_project from_template: 'using-adder'
+
+    prj.create_lists_from_default_template package: <<~PACK
+      set(DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/_deps/testpack-adder-src)
+      CPMAddPackage(
+        NAME testpack-adder
+        SOURCE_DIR ${DOWNLOAD_DIR}
+        DOWNLOAD_COMMAND git clone --depth 1 --branch v1.0.0 https://github.com/cpm-cmake/testpack-adder.git ${DOWNLOAD_DIR}
+        OPTIONS "ADDER_BUILD_TESTS OFF"
+      )
+    PACK
+
+    # configure with unpopulated cache
+    assert_success prj.configure
+    assert_success prj.build
+  end
+
+end


### PR DESCRIPTION
Previously we considered `DOWNLOAD_COMMAND` to be a single option argument. However as pointed out by @jm4R, it is indeed a multi value argument. This PR fixes the declaration and adds an integration test case.

Fixes #472