### PR TITLE
Add SPDX tags to get_cpm.cmake to comply with MIT

### DIFF
--- a/cmake/get_cpm.cmake
+++ b/cmake/get_cpm.cmake
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# SPDX-FileCopyrightText: Copyright (c) 2019-2022 Lars Melchior and contributors
+
 set(CPM_DOWNLOAD_VERSION 1.0.0-development-version)
 
 if(CPM_SOURCE_CACHE)


### PR DESCRIPTION
Add [SPDX][1] licensing/copyright tags to the `get_cpm.cmake` script, so that anybody that copies the `get_cpm.cmake` script into their repo (following the instructions in the README.md) will automatically comply with CPM's MIT license.

It's possible that we could just copy the entire MIT License info over (aka like what [`cmake/CPM.cmake` does](https://github.com/cpm-cmake/CPM.cmake/blob/ee556fc5556b88c3c77e3d758bec75574160f59d/cmake/CPM.cmake#L5-L27), but most modern open-source projects (like the Linux kernel) just use SPDX tags to keep things simpler.

[1]: https://spdx.dev/