### PR TITLE
Fix new release script to use correct version and hash sum

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,9 +15,9 @@ jobs:
       - name: Set CPM version by tag
         run: |
           mkdir dist
-          sed -e "s/1.0.0-development-version/${GITHUB_REF/refs\/tags\//v}/g" cmake/CPM.cmake > dist/CPM.cmake
-          sed -e "s/1.0.0-development-version/${GITHUB_REF/refs\/tags\//v}/g" \
-              -e "s/EMPTY_HASH_SUM/$(sha256sum cmake/CPM.cmake | cut -d' ' -f1)/" cmake/get_cpm.cmake > dist/get_cpm.cmake
+          sed -e "s/1.0.0-development-version/${GITHUB_REF/refs\/tags\/v}/g" cmake/CPM.cmake > dist/CPM.cmake
+          sed -e "s/1.0.0-development-version/${GITHUB_REF/refs\/tags\/v}/g" \
+              -e "s/CPM_HASH_SUM_PLACEHOLDER/$(sha256sum dist/CPM.cmake | cut -d' ' -f1)/" cmake/get_cpm.cmake > dist/get_cpm.cmake
 
       - name: Upload CPM.cmake to release
         uses: svenstaro/upload-release-action@v1-release

--- a/cmake/get_cpm.cmake
+++ b/cmake/get_cpm.cmake
@@ -16,7 +16,8 @@ endif()
 # Expand relative path. This is important if the provided path contains a tilde (~)
 get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
 
-message(STATUS "Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
+message(STATUS "Using CPM at ${CPM_DOWNLOAD_LOCATION}")
+
 file(
   DOWNLOAD
   https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
@@ -24,12 +25,12 @@ file(
   STATUS CPM_DOWNLOAD_STATUS
   EXPECTED_HASH SHA256=${CPM_HASH_SUM}
 )
+
 list(GET CPM_DOWNLOAD_STATUS 0 CPM_DOWNLOAD_STATUS_CODE)
-list(GET CPM_DOWNLOAD_STATUS 1 CPM_DOWNLOAD_ERROR_MESSAGE)
-if(${CPM_DOWNLOAD_STATUS_CODE} EQUAL 0)
-  message(STATUS "CPM: Download completed successfully.")
-else()
-  message(FATAL_ERROR "CPM: Error occurred during download: ${CPM_DOWNLOAD_ERROR_MESSAGE}")
+if(NOT ${CPM_DOWNLOAD_STATUS_CODE} EQUAL 0)
+  # give a fatal error when download fails
+  list(GET CPM_DOWNLOAD_STATUS 1 CPM_DOWNLOAD_ERROR_MESSAGE)
+  message(FATAL_ERROR "Error occurred during download of CPM: ${CPM_DOWNLOAD_ERROR_MESSAGE}")
 endif()
 
 include(${CPM_DOWNLOAD_LOCATION})

--- a/cmake/get_cpm.cmake
+++ b/cmake/get_cpm.cmake
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
 
 set(CPM_DOWNLOAD_VERSION 1.0.0-development-version)
-set(CPM_HASH_SUM "HASH_SUM_PLACEHOLDER")
+set(CPM_HASH_SUM "CPM_HASH_SUM_PLACEHOLDER")
 
 if(CPM_SOURCE_CACHE)
   set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")


### PR DESCRIPTION
This fixes an issue with the new download script from #474, discovered after testing, where the hash and version were not properly replaced by the release script workflow. Additionally, it now only logs on errors instead of on each successful run of the download command.