### PR TITLE
Remove logs in get_cpm.cmake script

### DIFF
--- a/cmake/get_cpm.cmake
+++ b/cmake/get_cpm.cmake
@@ -16,11 +16,9 @@ endif()
 # Expand relative path. This is important if the provided path contains a tilde (~)
 get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
 
-file(
-  DOWNLOAD
-  https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
-  ${CPM_DOWNLOAD_LOCATION}
-  EXPECTED_HASH SHA256=${CPM_HASH_SUM}
+file(DOWNLOAD
+     https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+     ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM}
 )
 
 include(${CPM_DOWNLOAD_LOCATION})

--- a/cmake/get_cpm.cmake
+++ b/cmake/get_cpm.cmake
@@ -16,21 +16,11 @@ endif()
 # Expand relative path. This is important if the provided path contains a tilde (~)
 get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
 
-message(STATUS "Using CPM at ${CPM_DOWNLOAD_LOCATION}")
-
 file(
   DOWNLOAD
   https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
   ${CPM_DOWNLOAD_LOCATION}
-  STATUS CPM_DOWNLOAD_STATUS
   EXPECTED_HASH SHA256=${CPM_HASH_SUM}
 )
-
-list(GET CPM_DOWNLOAD_STATUS 0 CPM_DOWNLOAD_STATUS_CODE)
-if(NOT ${CPM_DOWNLOAD_STATUS_CODE} EQUAL 0)
-  # give a fatal error when download fails
-  list(GET CPM_DOWNLOAD_STATUS 1 CPM_DOWNLOAD_ERROR_MESSAGE)
-  message(FATAL_ERROR "Error occurred during download of CPM: ${CPM_DOWNLOAD_ERROR_MESSAGE}")
-endif()
 
 include(${CPM_DOWNLOAD_LOCATION})


### PR DESCRIPTION
Previously, when multiple dependencies use the `get_cpm.cmake` script, a log is emitted each time they attempt to import the CPM.cmake script. As this is a no-op in most cases the log could be confusing, which is why it should be removed. Additionally, the checks for the download status are unnecessary, as CMake will emit them and fail the configuration in case the SHA hashes don't match.