### PR TITLE
Update catch2 in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ include(cmake/CPM.cmake)
 
 CPMAddPackage("gh:fmtlib/fmt#7.1.3")
 CPMAddPackage("gh:nlohmann/json@3.10.5")
-CPMAddPackage("gh:catchorg/Catch2@3.2.1")
+CPMAddPackage("gh:catchorg/Catch2@3.4.0")
 
 # link dependencies
 target_link_libraries(main fmt::fmt nlohmann_json::nlohmann_json Catch2::Catch2WithMain)

--- a/examples/catch2/CMakeLists.txt
+++ b/examples/catch2/CMakeLists.txt
@@ -7,7 +7,7 @@ project(CPMExampleCatch2)
 include(../../cmake/CPM.cmake)
 
 CPMAddPackage("gh:cpm-cmake/testpack-fibonacci@2.0")
-CPMAddPackage("gh:catchorg/Catch2@3.2.1")
+CPMAddPackage("gh:catchorg/Catch2@3.4.0")
 
 # ---- Create binary ----
 


### PR DESCRIPTION
This PR updates the version of catch2 used in the Readme and examples directory, as the previous version was showing a compilation error on CI: `error: unknown type name 'uint8_t'`. Most likely this was caused by an update of the clang version used in the `ubuntu-latest` runner on GitHub.

Affected PRs: #516, #517.