### PR TITLE
Re-export `CMAKE_MODULE_PATH`

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -756,6 +756,7 @@ function(CPMAddPackage)
         "${CPM_ARGS_SYSTEM}"
         "${CPM_ARGS_OPTIONS}"
       )
+      set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} PARENT_SCOPE)
       set(PACKAGE_INFO "${PACKAGE_INFO} at ${download_directory}")
 
       # As the source dir is already cached/populated, we override the call to FetchContent.
@@ -815,6 +816,7 @@ function(CPMAddPackage)
         "${CPM_ARGS_SYSTEM}"
         "${CPM_ARGS_OPTIONS}"
       )
+      set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} PARENT_SCOPE)
     endif()
     cpm_get_fetch_properties("${CPM_ARGS_NAME}")
   endif()
@@ -986,6 +988,7 @@ function(
     set(CPM_OLD_INDENT "${CPM_INDENT}")
     set(CPM_INDENT "${CPM_INDENT} ${PACKAGE}:")
     add_subdirectory(${SOURCE_DIR} ${BINARY_DIR} ${addSubdirectoryExtraArgs})
+    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} PARENT_SCOPE)
     set(CPM_INDENT "${CPM_OLD_INDENT}")
   endif()
 endfunction()

--- a/examples/catch2/CMakeLists.txt
+++ b/examples/catch2/CMakeLists.txt
@@ -17,5 +17,7 @@ target_compile_features(CPMExampleCatch2 PRIVATE cxx_std_17)
 
 # ---- Enable testing ----
 
+include(Catch)
+
 enable_testing()
-add_test(CPMExampleCatch2 CPMExampleCatch2)
+catch_discover_tests(CPMExampleCatch2)


### PR DESCRIPTION
This pull request re-export the `CMAKE_MODULE_PATH` variable to the parent scope from the `add_subdirectory` function. This function is useful because some packages, like Catch2, export the `CMAKE_MODULE_PATH` of their script files to the parent scope, as could be seen here:

[![image](https://github.com/cpm-cmake/CPM.cmake/assets/10202888/2b519d20-91ea-4197-bdf0-caa5c64eedcd)](https://github.com/catchorg/Catch2/blob/863c662c0eff026300f4d729a7054e90d6d12cdd/CMakeLists.txt#L45-L53)


While this implementation may be somewhat unconventional and a bit hacky, I don't know of any better ways to solve this issue. It allows script files to be directly used instead of having to delve deep into the project source files. Previously, if we wanted to use the `catch_discover_tests` function with Catch2, we had to do the following:

```cmake
CPMAddPackage("gh:catchorg/Catch2@3.4.0")
include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
```