### PR TITLE
Custom cache directory name

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ Note that passing the variable as a configure option to CMake will always overri
 
 You can use `CPM_SOURCE_CACHE` on GitHub Actions workflows [cache](https://github.com/actions/cache) and combine it with ccache, to make your CI faster. See the [wiki](https://github.com/cpm-cmake/CPM.cmake/wiki/Caching-with-CPM.cmake-and-ccache-on-GitHub-Actions) for more info.
 
+The directory where the version for a project is stored is by default the hash of the arguments to `CPMAddPackage()`.
+If for instance the patch command uses external files, the directory name can be set with the argument `CUSTOM_CACHE_DIR`.
+
 ### CPM_DOWNLOAD_ALL
 
 If set, CPM will forward all calls to `CPMFindPackage` as `CPMAddPackage`.

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Note that passing the variable as a configure option to CMake will always overri
 You can use `CPM_SOURCE_CACHE` on GitHub Actions workflows [cache](https://github.com/actions/cache) and combine it with ccache, to make your CI faster. See the [wiki](https://github.com/cpm-cmake/CPM.cmake/wiki/Caching-with-CPM.cmake-and-ccache-on-GitHub-Actions) for more info.
 
 The directory where the version for a project is stored is by default the hash of the arguments to `CPMAddPackage()`.
-If for instance the patch command uses external files, the directory name can be set with the argument `CUSTOM_CACHE_DIR`.
+If for instance the patch command uses external files, the directory name can be set with the argument `CUSTOM_CACHE_KEY`.
 
 ### CPM_DOWNLOAD_ALL
 

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -540,6 +540,7 @@ function(CPMAddPackage)
       GIT_SHALLOW
       EXCLUDE_FROM_ALL
       SOURCE_SUBDIR
+      CUSTOM_CACHE_DIR
   )
 
   set(multiValueArgs URL OPTIONS DOWNLOAD_COMMAND)
@@ -710,7 +711,10 @@ function(CPMAddPackage)
     string(TOLOWER ${CPM_ARGS_NAME} lower_case_name)
     set(origin_parameters ${CPM_ARGS_UNPARSED_ARGUMENTS})
     list(SORT origin_parameters)
-    if(CPM_USE_NAMED_CACHE_DIRECTORIES)
+    if(CPM_ARGS_CUSTOM_CACHE_DIR)
+      # Application set a custom unique directory name
+      set(download_directory ${CPM_SOURCE_CACHE}/${lower_case_name}/${CPM_ARGS_CUSTOM_CACHE_DIR})
+    elseif(CPM_USE_NAMED_CACHE_DIRECTORIES)
       string(SHA1 origin_hash "${origin_parameters};NEW_CACHE_STRUCTURE_TAG")
       set(download_directory ${CPM_SOURCE_CACHE}/${lower_case_name}/${origin_hash}/${CPM_ARGS_NAME})
     else()

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -540,7 +540,7 @@ function(CPMAddPackage)
       GIT_SHALLOW
       EXCLUDE_FROM_ALL
       SOURCE_SUBDIR
-      CUSTOM_CACHE_DIR
+      CUSTOM_CACHE_KEY
   )
 
   set(multiValueArgs URL OPTIONS DOWNLOAD_COMMAND)
@@ -711,9 +711,9 @@ function(CPMAddPackage)
     string(TOLOWER ${CPM_ARGS_NAME} lower_case_name)
     set(origin_parameters ${CPM_ARGS_UNPARSED_ARGUMENTS})
     list(SORT origin_parameters)
-    if(CPM_ARGS_CUSTOM_CACHE_DIR)
+    if(CPM_ARGS_CUSTOM_CACHE_KEY)
       # Application set a custom unique directory name
-      set(download_directory ${CPM_SOURCE_CACHE}/${lower_case_name}/${CPM_ARGS_CUSTOM_CACHE_DIR})
+      set(download_directory ${CPM_SOURCE_CACHE}/${lower_case_name}/${CPM_ARGS_CUSTOM_CACHE_KEY})
     elseif(CPM_USE_NAMED_CACHE_DIRECTORIES)
       string(SHA1 origin_hash "${origin_parameters};NEW_CACHE_STRUCTURE_TAG")
       set(download_directory ${CPM_SOURCE_CACHE}/${lower_case_name}/${origin_hash}/${CPM_ARGS_NAME})

--- a/test/unit/cache.cmake
+++ b/test/unit/cache.cmake
@@ -140,7 +140,7 @@ assert_not_exists("${CPM_SOURCE_CACHE_DIR}/fibonacci")
 
 # Use custom cache directory
 
-set(FIBONACCI_PACKAGE_ARGS "CUSTOM_CACHE_DIR my_custom_unique_dir GIT_TAG e9ebf168ca0fffaa4ef8c6fefc6346aaa22f6ed5")
+set(FIBONACCI_PACKAGE_ARGS "CUSTOM_CACHE_KEY my_custom_unique_dir GIT_TAG e9ebf168ca0fffaa4ef8c6fefc6346aaa22f6ed5")
 set(FIBONACCI_VERSION 1.1)
 update_cmake_lists()
 

--- a/test/unit/cache.cmake
+++ b/test/unit/cache.cmake
@@ -140,7 +140,9 @@ assert_not_exists("${CPM_SOURCE_CACHE_DIR}/fibonacci")
 
 # Use custom cache directory
 
-set(FIBONACCI_PACKAGE_ARGS "CUSTOM_CACHE_KEY my_custom_unique_dir GIT_TAG e9ebf168ca0fffaa4ef8c6fefc6346aaa22f6ed5")
+set(FIBONACCI_PACKAGE_ARGS
+    "CUSTOM_CACHE_KEY my_custom_unique_dir GIT_TAG e9ebf168ca0fffaa4ef8c6fefc6346aaa22f6ed5"
+)
 set(FIBONACCI_VERSION 1.1)
 update_cmake_lists()
 

--- a/test/unit/cache.cmake
+++ b/test/unit/cache.cmake
@@ -137,3 +137,17 @@ execute_process(
 
 assert_equal(${ret} "0")
 assert_not_exists("${CPM_SOURCE_CACHE_DIR}/fibonacci")
+
+# Use custom cache directory
+
+set(FIBONACCI_PACKAGE_ARGS "CUSTOM_CACHE_DIR my_custom_unique_dir GIT_TAG e9ebf168ca0fffaa4ef8c6fefc6346aaa22f6ed5")
+set(FIBONACCI_VERSION 1.1)
+update_cmake_lists()
+
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -E env "CPM_SOURCE_CACHE=${CPM_SOURCE_CACHE_DIR}" ${CMAKE_COMMAND}
+          "-S${CMAKE_CURRENT_LIST_DIR}/remote_dependency" "-B${TEST_BUILD_DIR}" RESULT_VARIABLE ret
+)
+
+assert_equal(${ret} "0")
+assert_exists("${CPM_SOURCE_CACHE_DIR}/fibonacci/my_custom_unique_dir")


### PR DESCRIPTION
Fixes #542 

Enable setting a custom directory name for cached packages. Required if e.g. patch_command uses external variables or just to set a human readable name.
Unit test added. 
