### PR TITLE
feature: allow additional arguments after shorthand syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ If an additional optional parameter `SYSTEM` is set to a truthy value, the SYSTE
 See the [add_subdirectory ](https://cmake.org/cmake/help/latest/command/add_subdirectory.html?highlight=add_subdirectory)
 and [SYSTEM](https://cmake.org/cmake/help/latest/prop_tgt/SYSTEM.html#prop_tgt:SYSTEM) target property for details.
 
-A single-argument compact syntax is also supported:
+A shorthand syntax is also supported:
 
 ```cmake
 # A git package from a given uri with a version
@@ -109,6 +109,13 @@ CPMAddPackage("https://example.com/my-package-1.2.3.zip")
 CPMAddPackage("https://example.com/my-package-1.2.3.zip#MD5=68e20f674a48be38d60e129f600faf7d")
 # An archive package from a given url. The version is explicitly given
 CPMAddPackage("https://example.com/my-package.zip@1.2.3")
+```
+
+Additionally, the shorthand syntax can be combined with the other options from above:
+```cmake
+CPMAddPackage("gh:nlohmann/json@3.9.1"
+  OPTIONS "JSON_BuildTests OFF"
+)
 ```
 
 After calling `CPMAddPackage`, the following variables are defined in the local scope, where `<dependency>` is the name of the dependency.

--- a/README.md
+++ b/README.md
@@ -403,12 +403,8 @@ CPMAddPackage("gh:jbeder/yaml-cpp#yaml-cpp-0.6.3@0.6.3")
 ### [nlohmann/json](https://github.com/nlohmann/json)
 
 ```cmake
-CPMAddPackage(
-  NAME nlohmann_json
-  VERSION 3.9.1
-  GITHUB_REPOSITORY nlohmann/json
-  OPTIONS
-    "JSON_BuildTests OFF"
+CPMAddPackage("gh:nlohmann/json@3.9.1"
+  OPTIONS "JSON_BuildTests OFF"
 )
 ```
 
@@ -437,20 +433,15 @@ For a working example of using CPM to download and configure the Boost C++ Libra
 
 ```cmake
 # the install option has to be explicitly set to allow installation
-CPMAddPackage(
-  GITHUB_REPOSITORY jarro2783/cxxopts
-  VERSION 2.2.1
-  OPTIONS "CXXOPTS_BUILD_EXAMPLES NO" "CXXOPTS_BUILD_TESTS NO" "CXXOPTS_ENABLE_INSTALL YES"
+CPMAddPackage("gh:jarro2783/cxxopts@2.2.1"
+    OPTIONS "CXXOPTS_BUILD_EXAMPLES NO" "CXXOPTS_BUILD_TESTS NO" "CXXOPTS_ENABLE_INSTALL YES"
 )
 ```
 
 ### [google/benchmark](https://github.com/google/benchmark)
 
 ```cmake
-CPMAddPackage(
-  NAME benchmark
-  GITHUB_REPOSITORY google/benchmark
-  VERSION 1.5.2
+CPMAddPackage("gh:google/benchmark@1.5.2"
   OPTIONS "BENCHMARK_ENABLE_TESTING Off"
 )
 
@@ -463,11 +454,8 @@ endif()
 ### [Lua](https://www.lua.org)
 
 ```cmake
-CPMAddPackage(
-  NAME lua
-  GIT_REPOSITORY https://github.com/lua/lua.git
-  VERSION 5.3.5
-  DOWNLOAD_ONLY YES
+CPMAddPackage("gh:lua/lua@5.3.5"
+    DOWNLOAD_ONLY YES
 )
 
 if (lua_ADDED)

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -575,14 +575,6 @@ endfunction()
 function(CPMAddPackage)
   cpm_set_policies()
 
-  list(LENGTH ARGN argnLength)
-  if(argnLength EQUAL 1)
-    cpm_parse_add_package_single_arg("${ARGN}" ARGN)
-
-    # The shorthand syntax implies EXCLUDE_FROM_ALL and SYSTEM
-    set(ARGN "${ARGN};EXCLUDE_FROM_ALL;YES;SYSTEM;YES;")
-  endif()
-
   set(oneValueArgs
       NAME
       FORCE
@@ -604,6 +596,28 @@ function(CPMAddPackage)
   )
 
   set(multiValueArgs URL OPTIONS DOWNLOAD_COMMAND PATCHES)
+
+  list(LENGTH ARGN argnLength)
+
+  # Parse single shorthand argument
+  if(argnLength EQUAL 1)
+    cpm_parse_add_package_single_arg("${ARGN}" ARGN)
+
+    # The shorthand syntax implies EXCLUDE_FROM_ALL and SYSTEM
+    set(ARGN "${ARGN};EXCLUDE_FROM_ALL;YES;SYSTEM;YES;")
+
+    # Parse shorthand argument as first argument but with following arguments
+  elseif(
+    argnLength GREATER 1
+    AND NOT "${ARGV0}" IN_LIST oneValueArgs
+    AND NOT "${ARGV0}" IN_LIST multiValueArgs
+  )
+    list(POP_FRONT ARGN)
+    cpm_parse_add_package_single_arg("${ARGV0}" ARGV0)
+
+    # The shorthand syntax implies EXCLUDE_FROM_ALL and SYSTEM
+    set(ARGN "${ARGV0};${ARGN};EXCLUDE_FROM_ALL;YES;SYSTEM;YES;")
+  endif()
 
   cmake_parse_arguments(CPM_ARGS "" "${oneValueArgs}" "${multiValueArgs}" "${ARGN}")
 

--- a/test/integration/test_simple.rb
+++ b/test/integration/test_simple.rb
@@ -83,9 +83,38 @@ class Simple < IntegrationTest
       # ...and notably no test for adder, which must be disabled from the option override from above
       assert_equal ['simple', 'using-adder'], exes
     }
+    update_with_option_off_and_build_with_shorthand_syntax = -> {
+      prj.create_lists_from_default_template package: <<~PACK
+        CPMAddPackage(gh:cpm-cmake/testpack-adder@1.0.0
+          OPTIONS "ADDER_BUILD_TESTS OFF"
+        )
+      PACK
+      assert_success prj.configure
+      assert_success prj.build
+
+      exe_dir = File.join(prj.bin_dir, 'bin')
+      assert File.directory? exe_dir
+
+      exes = Dir[exe_dir + '/**/*'].filter {
+        # on multi-configuration generators (like Visual Studio) the executables will be in bin/<Config>
+        # also filter-out other artifacts like .pdb or .dsym
+        !File.directory?(_1) && File.stat(_1).executable?
+      }.map {
+        # remove .exe extension if any (there will be one on Windows)
+        File.basename(_1, '.exe')
+      }.sort
+
+      # we should end up with two executables
+      # * simple - the simple example from adder
+      # * using-adder - for this project
+      # ...and notably no test for adder, which must be disabled from the option override from above
+      assert_equal ['simple', 'using-adder'], exes
+
+    }
 
     create_with_commit_sha.()
     update_to_version_1.()
     update_with_option_off_and_build.()
+  update_with_option_off_and_build_with_shorthand_syntax.()
   end
 end


### PR DESCRIPTION
This allows to combine the shorthand syntax with additional arguments:
```
CPMAddPackage("gh:nlohmann/json@3.9.1" OPTIONS "JSON_BUildTests OFF")
```

This is much shorter than the longer syntax way of writing:
```
CPMAddPackage(
  NAME nlohmann_json
  VERSION 3.9.1
  GITHUB_REPOSITORY nlohmann/json
  OPTIONS
    "JSON_BuildTests OFF"
)
```