### PR TITLE
Use cpm_find_package to check if a package added

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -300,12 +300,6 @@ function(CPMFindPackage)
     return()
   endif()
 
-  cpm_check_if_package_already_added(${CPM_ARGS_NAME} "${CPM_ARGS_VERSION}")
-  if(CPM_PACKAGE_ALREADY_ADDED)
-    cpm_export_variables(${CPM_ARGS_NAME})
-    return()
-  endif()
-
   cpm_find_package(${CPM_ARGS_NAME} "${CPM_ARGS_VERSION}" ${CPM_ARGS_FIND_PACKAGE_ARGUMENTS})
 
   if(NOT CPM_PACKAGE_FOUND)


### PR DESCRIPTION
If I have a project, which has:

1. /CMakeLists.txt:

   ```cmake
   cmake_minimum_required(VERSION 3.29)
   project(test)
   include(./cmake/CPM.cmake)
   add_subdirectory(subdir)
   cpmfindpackage(
     NAME
     nlohmann_json
     VERSION
     3.11.2
     URL
     "https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz"
     EXCLUDE_FROM_ALL
     ON)

   if(NOT TARGET nlohmann_json::nlohmann_json)
     message(FATAL_ERROR "BUG")
   endif()
   ```
2. /subdir/CMakeLists.txt

   ```cmake
   cpmfindpackage(
     NAME
     nlohmann_json
     VERSION
     3.11.2
     URL
     "https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz"
     EXCLUDE_FROM_ALL
     ON)
   ```

When nlohmann_json is first founded by find_package,
CPM.cmake register this package and later call to CPMFindPackage will
not actually perform a find_package again, which leads to this buggy
behavior.

As CPM write a FindXXX.cmake file for packages added by CPM to pervert
find_package to get local package, I think directly use cpm_find_package
to check if a package is already added is good enough.
