### PR TITLE
Remove 'bug' from comment

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -391,8 +391,8 @@ function(cpm_parse_add_package_single_arg arg outArgs)
     # We don't try to parse the version if it's not provided explicitly. cpm_get_version_from_url
     # should do this at a later point
   else()
-    # We should never get here. This is an assertion and hitting it means there's a problem with the code
-    # above. A packageType was set, but not handled by this if-else.
+    # We should never get here. This is an assertion and hitting it means there's a problem with
+    # the code above. A packageType was set, but not handled by this if-else.
     message(FATAL_ERROR "${CPM_INDENT} Unsupported package type '${packageType}' of '${arg}'")
   endif()
 

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -391,8 +391,8 @@ function(cpm_parse_add_package_single_arg arg outArgs)
     # We don't try to parse the version if it's not provided explicitly. cpm_get_version_from_url
     # should do this at a later point
   else()
-    # We should never get here. This is an assertion and hitting it means there's a problem with
-    # the code above. A packageType was set, but not handled by this if-else.
+    # We should never get here. This is an assertion and hitting it means there's a problem with the
+    # code above. A packageType was set, but not handled by this if-else.
     message(FATAL_ERROR "${CPM_INDENT} Unsupported package type '${packageType}' of '${arg}'")
   endif()
 

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -391,7 +391,7 @@ function(cpm_parse_add_package_single_arg arg outArgs)
     # We don't try to parse the version if it's not provided explicitly. cpm_get_version_from_url
     # should do this at a later point
   else()
-    # We should never get here. This is an assertion and hitting it means there's a bug in the code
+    # We should never get here. This is an assertion and hitting it means there's a problem with the code
     # above. A packageType was set, but not handled by this if-else.
     message(FATAL_ERROR "${CPM_INDENT} Unsupported package type '${packageType}' of '${arg}'")
   endif()


### PR DESCRIPTION
This is a super simple change. The reason for it is that CLion, and probably other IDEs, will report this comment as a bug when looking at the TODOs of a project that indexes the `CPM.cmake` file. Avoiding the word `bug` prevents that.

I know that this is a stupid pull request, but it was ***bug***ging me.