### PR TITLE
Add example for using the SigC++ library

### DIFF
--- a/examples/libsigcplusplus/CMakeLists.txt
+++ b/examples/libsigcplusplus/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+
+project(CPMLibSigCppExample)
+
+# ---- Dependencies ----
+
+include(../../cmake/CPM.cmake)
+
+CPMAddPackage("gh:libsigcplusplus/libsigcplusplus#3.6.0")
+if(libsigcplusplus_ADDED)
+    set(SIGCPP_INCLUDE_DIRS ${libsigcplusplus_SOURCE_DIR} ${CPM_PACKAGE_libsigcplusplus_BINARY_DIR} )
+    set(SIGCPP_LIBRARY sigc-3.0)
+endif()
+
+# ---- Create binary ----
+
+add_executable(CPMLibSigCppExample main.cpp)
+target_include_directories(CPMLibSigCppExample PUBLIC ${SIGCPP_INCLUDE_DIRS})
+target_link_libraries(CPMLibSigCppExample ${SIGCPP_LIBRARY})
+target_compile_features(CPMLibSigCppExample PRIVATE cxx_std_17)

--- a/examples/libsigcplusplus/main.cpp
+++ b/examples/libsigcplusplus/main.cpp
@@ -1,0 +1,18 @@
+#include <sigc++/sigc++.h>
+#include <iostream>
+
+void example_callback() {
+    std::cout << "Hello World" << std::endl;
+}
+
+sigc::signal<void(void)> signal_say_hi;
+
+int main() {
+    // Register callback
+    signal_say_hi.connect(sigc::ptr_fun(&example_callback));
+
+    // Emit signal, so that callback gets called
+    signal_say_hi.emit();
+
+    return 0;
+}


### PR DESCRIPTION
I managed to get the SigC++ library to work with CPM.

Although  libsigcplusplus project has a CMakeLists.txt file, the includes and library target name did not end up in a CMake variable right away. That required some fiddling.

I hope you like my contribution and I'm happy to hear if things can be improved.