### PR TITLE
replace deprecated calls to FetchContent_Populate

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-latest, windows-2022, macos-latest]
         # we want to ensure compatibility with a recent CMake version as well as the lowest officially supported
         # legacy version that we define as the default version of the second-latest Ubuntu LTS release currently available
-        cmake_version: ['3.16.3', '3.27.5']
+        cmake_version: ['3.16.3', '3.27.5', '3.30.0']
         exclude:
           # there seems to be an issue with CMake 3.16 not finding a C++ compiler on windows-2022 
           - os: windows-2022

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -873,6 +873,13 @@ function(CPMAddPackage)
       if(${CPM_ARGS_SYSTEM})
         list(APPEND fetchContentDeclareExtraArgs SYSTEM)
       endif()
+      if(CPM_ARGS_OPTIONS)
+        foreach(OPTION ${CPM_ARGS_OPTIONS})
+          cpm_parse_option("${OPTION}")
+          set(${OPTION_KEY} "${OPTION_VALUE}")
+        endforeach()
+      endif()
+
       cpm_declare_fetch(
         "${CPM_ARGS_NAME}"
         ${fetchContentDeclareExtraArgs}

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -878,7 +878,7 @@ function(CPMAddPackage)
         list(APPEND fetchContentDeclareExtraArgs SOURCE_SUBDIR ${CPM_ARGS_SOURCE_SUBDIR})
       endif()
       # For CMake version <3.28 OPTIONS are parsed in cpm_add_subdirectory
-      if(CPM_ARGS_OPTIONS)
+      if(CPM_ARGS_OPTIONS AND NOT DOWNLOAD_ONLY)
         foreach(OPTION ${CPM_ARGS_OPTIONS})
           cpm_parse_option("${OPTION}")
           set(${OPTION_KEY} "${OPTION_VALUE}")

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -862,11 +862,38 @@ function(CPMAddPackage)
   )
 
   if(NOT CPM_SKIP_FETCH)
-    cpm_fetch_package("${CPM_ARGS_NAME}" populated ${CPM_ARGS_UNPARSED_ARGUMENTS})
+    # CMake 3.28 added EXCLUDE, SYSTEM (3.25), and SOURCE_SUBDIR (3.18) to FetchContent_Declare.
+    # Calling FetchContent_MakeAvailable will then internally forward these options to
+    # add_subdirectory. Up until these changes, we had to call FetchContent_Populate and
+    # add_subdirectory separately, which is no longer necessary and has been deprecated as of 3.30.
+    set(fetchContentDeclareExtraArgs "")
+    if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.28.0")
+      if(${CPM_ARGS_EXCLUDE_FROM_ALL})
+        list(APPEND fetchContentDeclareExtraArgs EXCLUDE_FROM_ALL)
+      endif()
+      if(${CPM_ARGS_SYSTEM})
+        list(APPEND fetchContentDeclareExtraArgs SYSTEM)
+      endif()
+      if(DEFINED CPM_ARGS_SOURCE_SUBDIR)
+        list(APPEND fetchContentDeclareExtraArgs SOURCE_SUBDIR ${CPM_ARGS_SOURCE_SUBDIR})
+      endif()
+      # For CMake version <3.28 OPTIONS are parsed in cpm_add_subdirectory
+      if(CPM_ARGS_OPTIONS AND NOT DOWNLOAD_ONLY)
+        foreach(OPTION ${CPM_ARGS_OPTIONS})
+          cpm_parse_option("${OPTION}")
+          set(${OPTION_KEY} "${OPTION_VALUE}")
+        endforeach()
+      endif()
+    endif()
+    cpm_declare_fetch(
+      "${CPM_ARGS_NAME}" ${fetchContentDeclareExtraArgs} "${CPM_ARGS_UNPARSED_ARGUMENTS}"
+    )
+
+    cpm_fetch_package("${CPM_ARGS_NAME}" ${DOWNLOAD_ONLY} populated ${CPM_ARGS_UNPARSED_ARGUMENTS})
     if(CPM_SOURCE_CACHE AND download_directory)
       file(LOCK ${download_directory}/../cmake.lock RELEASE)
     endif()
-    if(${populated})
+    if(${populated} AND ${CMAKE_VERSION} VERSION_LESS "3.28.0")
       cpm_add_subdirectory(
         "${CPM_ARGS_NAME}"
         "${DOWNLOAD_ONLY}"
@@ -976,7 +1003,17 @@ function(CPMGetPackageVersion PACKAGE OUTPUT)
   )
 endfunction()
 
-# returns properties for a package previously defined by cpm_fetch_package
+# declares a package in FetchContent_Declare
+function(cpm_declare_fetch PACKAGE)
+  if(${CPM_DRY_RUN})
+    cpm_message(STATUS "${CPM_INDENT} Package not declared (dry run)")
+    return()
+  endif()
+
+  FetchContent_Declare(${PACKAGE} ${ARGN})
+endfunction()
+
+# returns properties for a package previously defined by cpm_declare_fetch
 function(cpm_get_fetch_properties PACKAGE)
   if(${CPM_DRY_RUN})
     return()
@@ -1043,7 +1080,7 @@ endfunction()
 
 # downloads a previously declared package via FetchContent and exports the variables
 # `${PACKAGE}_SOURCE_DIR` and `${PACKAGE}_BINARY_DIR` to the parent scope
-function(cpm_fetch_package PACKAGE populated)
+function(cpm_fetch_package PACKAGE DOWNLOAD_ONLY populated)
   set(${populated}
       FALSE
       PARENT_SCOPE
@@ -1058,14 +1095,24 @@ function(cpm_fetch_package PACKAGE populated)
   string(TOLOWER "${PACKAGE}" lower_case_name)
 
   if(NOT ${lower_case_name}_POPULATED)
-    FetchContent_Populate(
-      ${PACKAGE}
-      QUIET
-      SOURCE_DIR "${CPM_FETCHCONTENT_BASE_DIR}/${lower_case_name}-src"
-      BINARY_DIR "${CPM_FETCHCONTENT_BASE_DIR}/${lower_case_name}-build"
-      SUBBUILD_DIR "${CPM_FETCHCONTENT_BASE_DIR}/${lower_case_name}-subbuild"
-      ${ARGN}
-    )
+    if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.28.0")
+      if(DOWNLOAD_ONLY)
+        # MakeAvailable will call add_subdirectory internally which is not what we want when
+        # DOWNLOAD_ONLY is set. Populate will only download the dependency without adding it to the
+        # build
+        FetchContent_Populate(
+          ${PACKAGE}
+          SOURCE_DIR "${CPM_FETCHCONTENT_BASE_DIR}/${lower_case_name}-src"
+          BINARY_DIR "${CPM_FETCHCONTENT_BASE_DIR}/${lower_case_name}-build"
+          SUBBUILD_DIR "${CPM_FETCHCONTENT_BASE_DIR}/${lower_case_name}-subbuild"
+          ${ARGN}
+        )
+      else()
+        FetchContent_MakeAvailable(${PACKAGE})
+      endif()
+    else()
+      FetchContent_Populate(${PACKAGE})
+    endif()
     set(${populated}
         TRUE
         PARENT_SCOPE

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -865,29 +865,28 @@ function(CPMAddPackage)
     # CMake 3.28 added EXCLUDE and SYSTEM(3.25) to FetchContent_Declare.
     # Calling FetchContent_MakeAvailable will than call add_subdirectory internally with the EXCLUDE
     # and SYSTEM flags. No need for CPM to do this manually anymore.
+    set(fetchContentDeclareExtraArgs "")
     if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.28.0")
-      set(fetchContentDeclareExtraArgs "")
       if(${CPM_ARGS_EXCLUDE_FROM_ALL})
         list(APPEND fetchContentDeclareExtraArgs EXCLUDE_FROM_ALL)
       endif()
       if(${CPM_ARGS_SYSTEM})
         list(APPEND fetchContentDeclareExtraArgs SYSTEM)
       endif()
+      # For CMake version <3.28 OPTIONS are parsed in cpm_add_subdirectory
       if(CPM_ARGS_OPTIONS)
         foreach(OPTION ${CPM_ARGS_OPTIONS})
           cpm_parse_option("${OPTION}")
           set(${OPTION_KEY} "${OPTION_VALUE}")
         endforeach()
       endif()
-
-      cpm_declare_fetch(
-        "${CPM_ARGS_NAME}"
-        ${fetchContentDeclareExtraArgs}
-        "${CPM_ARGS_UNPARSED_ARGUMENTS}"
-      )
-    else()
-      cpm_declare_fetch("${CPM_ARGS_NAME}" "${CPM_ARGS_UNPARSED_ARGUMENTS}")
     endif()
+    cpm_declare_fetch(
+      "${CPM_ARGS_NAME}"
+      ${fetchContentDeclareExtraArgs}
+      "${CPM_ARGS_UNPARSED_ARGUMENTS}"
+    )
+
     cpm_fetch_package("${CPM_ARGS_NAME}" populated)
     if(CPM_SOURCE_CACHE AND download_directory)
       file(LOCK ${download_directory}/../cmake.lock RELEASE)

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -862,9 +862,10 @@ function(CPMAddPackage)
   )
 
   if(NOT CPM_SKIP_FETCH)
-    # CMake 3.28 added EXCLUDE and SYSTEM(3.25) to FetchContent_Declare.
-    # Calling FetchContent_MakeAvailable will than call add_subdirectory internally with the EXCLUDE
-    # and SYSTEM flags. No need for CPM to do this manually anymore.
+    # CMake 3.28 added EXCLUDE, SYSTEM (3.25), and SOURCE_SUBDIR (3.18) to FetchContent_Declare.
+    # Calling FetchContent_MakeAvailable will then internally forward these options to
+    # add_subdirectory. Up until these changes, we had to call FetchContent_Populate and
+    # add_subdirectory separately, which is no longer necessary and has been deprecated as of 3.30.
     set(fetchContentDeclareExtraArgs "")
     if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.28.0")
       if(${CPM_ARGS_EXCLUDE_FROM_ALL})
@@ -872,6 +873,9 @@ function(CPMAddPackage)
       endif()
       if(${CPM_ARGS_SYSTEM})
         list(APPEND fetchContentDeclareExtraArgs SYSTEM)
+      endif()
+      if(DEFINED CPM_ARGS_SOURCE_SUBDIR)
+        list(APPEND fetchContentDeclareExtraArgs SOURCE_SUBDIR ${CPM_ARGS_SOURCE_SUBDIR})
       endif()
       # For CMake version <3.28 OPTIONS are parsed in cpm_add_subdirectory
       if(CPM_ARGS_OPTIONS)
@@ -882,9 +886,7 @@ function(CPMAddPackage)
       endif()
     endif()
     cpm_declare_fetch(
-      "${CPM_ARGS_NAME}"
-      ${fetchContentDeclareExtraArgs}
-      "${CPM_ARGS_UNPARSED_ARGUMENTS}"
+      "${CPM_ARGS_NAME}" ${fetchContentDeclareExtraArgs} "${CPM_ARGS_UNPARSED_ARGUMENTS}"
     )
 
     cpm_fetch_package("${CPM_ARGS_NAME}" populated)


### PR DESCRIPTION
Fixes: #568 

The single argument signature for FetchContent_Populate is deprecated with CMake 3.30. 
It was used in order to call add_subdirectory manually with the EXCLUDE_FROM_ALL and SYSTEM flags. 
These have been added to FetchContent_Declare with 3.25 and 3.28. 

Calling FetchContent_MakeAvailable will then internally call add_subdirectory with EXCLUDE_FROM_ALL and SYSTEM. There is therefore no need to call this manually anymore.

This discussion explains the problem better: https://discourse.cmake.org/t/rfc-deprecating-direct-calls-to-fetchcontent-populate/8161

Have tested this on a few internal projects, and didn't notice any issues.
