### PR TITLE
fix: add --forward flag to PATCH_EXECUTABLE command

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -516,8 +516,6 @@ function(cpm_add_patches)
       list(APPEND temp_list "&&")
     endif()
     # Add the patch command to the list
-    # The --batch flag is used to prevent the patch command from asking for user input
-    # and it does not apply the patch if it is unnecessary.
     list(APPEND temp_list "${PATCH_EXECUTABLE}" "--batch" "-p1" "<" "${PATCH_FILE}")
   endforeach()
 

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -520,7 +520,7 @@ function(cpm_add_patches)
       APPEND
       temp_list
       "${PATCH_EXECUTABLE}"
-      "-t"
+      "-N"
       "-p1"
       "<"
       "${PATCH_FILE}"

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -516,7 +516,7 @@ function(cpm_add_patches)
       list(APPEND temp_list "&&")
     endif()
     # Add the patch command to the list
-    list(APPEND temp_list "${PATCH_EXECUTABLE}" "--batch" "-p1" "<" "${PATCH_FILE}")
+    list(APPEND temp_list "${PATCH_EXECUTABLE}" "-t" "-p1" "<" "${PATCH_FILE}")
   endforeach()
 
   # Move temp out into parent scope.

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -516,7 +516,9 @@ function(cpm_add_patches)
       list(APPEND temp_list "&&")
     endif()
     # Add the patch command to the list
-    list(APPEND temp_list "${PATCH_EXECUTABLE}" "-p1" "<" "${PATCH_FILE}")
+    # The --batch flag is used to prevent the patch command from asking for user input
+    # and it does not apply the patch if it is unnecessary.
+    list(APPEND temp_list "${PATCH_EXECUTABLE}" "--batch" "-p1" "<" "${PATCH_FILE}")
   endforeach()
 
   # Move temp out into parent scope.

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -516,7 +516,15 @@ function(cpm_add_patches)
       list(APPEND temp_list "&&")
     endif()
     # Add the patch command to the list
-    list(APPEND temp_list "${PATCH_EXECUTABLE}" "-t" "-p1" "<" "${PATCH_FILE}")
+    list(
+      APPEND
+      temp_list
+      "${PATCH_EXECUTABLE}"
+      "-t"
+      "-p1"
+      "<"
+      "${PATCH_FILE}"
+    )
   endforeach()
 
   # Move temp out into parent scope.


### PR DESCRIPTION
Recent work by @ScottBailey making applying patches easy. However, I find that if the configuration is triggered more than once (necessary if the config changed), the tool may sometimes try to patch again the dependency. It then fails and the `cmake —build` command fails. It should be fine to just abort if the patch has already been applied, which is what `--forward` flag should do. We use `-N` as a shorthand for `--forward` in the code.