### PR TITLE
PATCHES : make it not fail when reconfiguring

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -516,7 +516,7 @@ function(cpm_add_patches)
       list(APPEND temp_list "&&")
     endif()
     # Add the patch command to the list
-    list(APPEND temp_list "${PATCH_EXECUTABLE}" "-p1 -N" "<" "${PATCH_FILE}")
+    list(APPEND temp_list "${PATCH_EXECUTABLE}" "-p1" "-N" "<" "${PATCH_FILE}")
   endforeach()
 
   # Move temp out into parent scope.

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -516,7 +516,15 @@ function(cpm_add_patches)
       list(APPEND temp_list "&&")
     endif()
     # Add the patch command to the list
-    list(APPEND temp_list "${PATCH_EXECUTABLE}" "-p1" "-Nn"  "<" "${PATCH_FILE}")
+    list(
+      APPEND
+      temp_list
+      "${PATCH_EXECUTABLE}"
+      "-p1"
+      "-N"
+      "<"
+      "${PATCH_FILE}"
+    )
   endforeach()
 
   # Move temp out into parent scope.
@@ -530,7 +538,7 @@ endfunction()
 # method to overwrite internal FetchContent properties, to allow using CPM.cmake to overload
 # FetchContent calls. As these are internal cmake properties, this method should be used carefully
 # and may need modification in future CMake versions. Source:
-# https://github.com/Kitware/CMake/blob/dc3d0b5a0a7d26d43d6cfeb511e224533b5d188f/Modules/FetchContent.cmake#L1152
+# https://github.com/Kitware/CMake/blob/dc3d0b5a0a7d26d43d6cfeb511e224533b5d188f/Modules/FetchContent.cmake #L1152
 function(cpm_override_fetchcontent contentName)
   cmake_parse_arguments(PARSE_ARGV 1 arg "" "SOURCE_DIR;BINARY_DIR" "")
   if(NOT "${arg_UNPARSED_ARGUMENTS}" STREQUAL "")
@@ -1038,7 +1046,7 @@ function(
       list(APPEND addSubdirectoryExtraArgs EXCLUDE_FROM_ALL)
     endif()
     if("${SYSTEM}" AND "${CMAKE_VERSION}" VERSION_GREATER_EQUAL "3.25")
-      # https://cmake.org/cmake/help/latest/prop_dir/SYSTEM.html#prop_dir:SYSTEM
+      # https://cmake.org/cmake/help/latest/prop_dir/SYSTEM.html #prop_dir:SYSTEM
       list(APPEND addSubdirectoryExtraArgs SYSTEM)
     endif()
     if(OPTIONS)

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -516,7 +516,7 @@ function(cpm_add_patches)
       list(APPEND temp_list "&&")
     endif()
     # Add the patch command to the list
-    list(APPEND temp_list "${PATCH_EXECUTABLE}" "-p1" "-N" "<" "${PATCH_FILE}")
+    list(APPEND temp_list "${PATCH_EXECUTABLE}" "-p 1 " "-N" "<" "${PATCH_FILE}")
   endforeach()
 
   # Move temp out into parent scope.

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -516,7 +516,7 @@ function(cpm_add_patches)
       list(APPEND temp_list "&&")
     endif()
     # Add the patch command to the list
-    list(APPEND temp_list "${PATCH_EXECUTABLE}" "--strip=1" "-N" "<" "${PATCH_FILE}")
+    list(APPEND temp_list "${PATCH_EXECUTABLE}" "-N" "-p1" "<" "${PATCH_FILE}")
   endforeach()
 
   # Move temp out into parent scope.

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -516,7 +516,7 @@ function(cpm_add_patches)
       list(APPEND temp_list "&&")
     endif()
     # Add the patch command to the list
-    list(APPEND temp_list "${PATCH_EXECUTABLE}" "-N" "-p1" "<" "${PATCH_FILE}")
+    list(APPEND temp_list "${PATCH_EXECUTABLE}" "--forward" "-p1" "<" "${PATCH_FILE}")
   endforeach()
 
   # Move temp out into parent scope.

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -516,7 +516,7 @@ function(cpm_add_patches)
       list(APPEND temp_list "&&")
     endif()
     # Add the patch command to the list
-    list(APPEND temp_list "${PATCH_EXECUTABLE}" "--forward" "-p1" "<" "${PATCH_FILE}")
+    list(APPEND temp_list "${PATCH_EXECUTABLE}" "-p1" "-Nn"  "<" "${PATCH_FILE}")
   endforeach()
 
   # Move temp out into parent scope.

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -516,7 +516,7 @@ function(cpm_add_patches)
       list(APPEND temp_list "&&")
     endif()
     # Add the patch command to the list
-    list(APPEND temp_list "${PATCH_EXECUTABLE}" "-p1" "-N" "<" "${PATCH_FILE}")
+    list(APPEND temp_list "${PATCH_EXECUTABLE}" "--strip=1" "-N" "<" "${PATCH_FILE}")
   endforeach()
 
   # Move temp out into parent scope.

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -516,7 +516,7 @@ function(cpm_add_patches)
       list(APPEND temp_list "&&")
     endif()
     # Add the patch command to the list
-    list(APPEND temp_list "${PATCH_EXECUTABLE}" "-p1" "<" "${PATCH_FILE}")
+    list(APPEND temp_list "${PATCH_EXECUTABLE}" "-pN1" "<" "${PATCH_FILE}")
   endforeach()
 
   # Move temp out into parent scope.

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -516,7 +516,7 @@ function(cpm_add_patches)
       list(APPEND temp_list "&&")
     endif()
     # Add the patch command to the list
-    list(APPEND temp_list "${PATCH_EXECUTABLE}" "-pN1" "<" "${PATCH_FILE}")
+    list(APPEND temp_list "${PATCH_EXECUTABLE}" "-p1 -N" "<" "${PATCH_FILE}")
   endforeach()
 
   # Move temp out into parent scope.

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -516,7 +516,7 @@ function(cpm_add_patches)
       list(APPEND temp_list "&&")
     endif()
     # Add the patch command to the list
-    list(APPEND temp_list "${PATCH_EXECUTABLE}" "-p 1 " "-N" "<" "${PATCH_FILE}")
+    list(APPEND temp_list "${PATCH_EXECUTABLE}" "-p1" "-N" "<" "${PATCH_FILE}")
   endforeach()
 
   # Move temp out into parent scope.


### PR DESCRIPTION
When there's PATCHES, if we reconfigure, it will fail with next logs:
```
-- CPM: Adding package PackageProject.cmake@1.11.2 (v1.11.2)
-- Populating packageproject.cmake
-- Configuring done (0.1s)
-- Generating done (0.0s)
-- Build files have been written to: /home/paxu/code/experiments/ModernCppStarterCPMBoostExample/build/_deps/packageproject.cmake-subbuild
[ 11%] Performing update step for 'packageproject.cmake-populate'
[ 22%] Performing patch step for 'packageproject.cmake-populate'
patching file CMakeLists.txt
Reversed (or previously applied) patch detected!  Assume -R? [n]
Apply anyway? [n]
Skipping patch.
1 out of 1 hunk ignored -- saving rejects to file CMakeLists.txt.rej
gmake[2]: *** [CMakeFiles/packageproject.cmake-populate.dir/build.make:118: packageproject.cmake-populate-prefix/src/packageproject.cmake-populate-stamp/packageproject.cmake-populate-patch] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/packageproject.cmake-populate.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2
CMake Error at /usr/share/cmake/Modules/FetchContent.cmake:1679 (message):
  Build step for packageproject.cmake failed: 2
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FetchContent.cmake:1819:EVAL:2 (__FetchContent_directPopulate)
  /usr/share/cmake/Modules/FetchContent.cmake:1819 (cmake_language)
  build/cmake/CPM_0.40.0.cmake:1074 (FetchContent_Populate)
  build/cmake/CPM_0.40.0.cmake:868 (cpm_fetch_package)
  cmake/packages/packageproject.cmake:6 (CPMAddPackage)
  CMakeLists.txt:31 (include)


-- Configuring incomplete, errors occurred!

```

This can be solved just by adding the `-N`  aka `--forward` to flags for `patch` command. `patch --help` for details.