### PR TITLE
Switch to non-deprecated FetchContent_Populate syntax (research PR)

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1085,9 +1085,9 @@ function(cpm_fetch_package PACKAGE populated fetch_args)
     set(${lower_case_name}_BINARY_DIR "${CPM_FETCHCONTENT_BASE_DIR}/${lower_case_name}-build")
   endif()
 
-  if(NOT ${lower_case_name}_POPULATED)
+  if(NOT "${${lower_case_name}_POPULATED}")
     # only exectute `FetchContent_Populate` if we specified a way to download the source
-    if(${lower_case_name}_UNPARSED_ARGUMENTS EQUAL "")
+    if(NOT "${${lower_case_name}_UNPARSED_ARGUMENTS}" STREQUAL "")
       FetchContent_Populate(
         ${PACKAGE}
         SOURCE_DIR ${${lower_case_name}_SOURCE_DIR}

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1087,13 +1087,15 @@ function(cpm_fetch_package PACKAGE populated fetch_args)
 
   if(NOT ${lower_case_name}_POPULATED)
     # only exectute `FetchContent_Populate` if we specified a way to download the source
-    if(${lower_case_name}_UNPARSED_ARGUMENTS)
+    if(${lower_case_name}_UNPARSED_ARGUMENTS EQUAL "")
       FetchContent_Populate(
         ${PACKAGE}
         SOURCE_DIR ${${lower_case_name}_SOURCE_DIR}
         BINARY_DIR ${${lower_case_name}_BINARY_DIR}
         "${${lower_case_name}_UNPARSED_ARGUMENTS}"
       )
+    else()
+      message("${lower_case_name}_UNPARSED_ARGUMENTS: ${${lower_case_name}_UNPARSED_ARGUMENTS}")
     endif()
     if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24.0")
       # ensure FetchContent knows the project is populated, this doesn't seem to be the case when

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1069,9 +1069,8 @@ function(cpm_fetch_package PACKAGE populated fetch_args)
   FetchContent_GetProperties(${PACKAGE})
   string(TOLOWER "${PACKAGE}" lower_case_name)
 
-  # with the new `FetchContent_Populate` syntax it seems that SOURCE and BINARY dir variables are no
-  # longer retrieved whne using `FetchContent_GetProperties`, so we need to implement the parsing
-  # and defaults for these ourselves.
+  # in case `FetchContent_GetProperties` does not retrieve the SOURCE_DIR and BINARY_DIR
+  # we need to parse them and their defaults manually.
   cmake_parse_arguments(${lower_case_name} "" "SOURCE_DIR;BINARY_DIR;SUBBUILD_DIR" "" ${fetch_args})
 
   if(NOT ${lower_case_name}_SOURCE_DIR)

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1094,8 +1094,6 @@ function(cpm_fetch_package PACKAGE populated fetch_args)
         BINARY_DIR ${${lower_case_name}_BINARY_DIR}
         "${${lower_case_name}_UNPARSED_ARGUMENTS}"
       )
-    else()
-      message("${lower_case_name}_UNPARSED_ARGUMENTS: ${${lower_case_name}_UNPARSED_ARGUMENTS}")
     endif()
     if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24.0")
       # ensure FetchContent knows the project is populated, this doesn't seem to be the case when

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1069,8 +1069,8 @@ function(cpm_fetch_package PACKAGE populated fetch_args)
   FetchContent_GetProperties(${PACKAGE})
   string(TOLOWER "${PACKAGE}" lower_case_name)
 
-  # in case `FetchContent_GetProperties` does not retrieve the SOURCE_DIR and BINARY_DIR
-  # we need to parse them and their defaults manually.
+  # in case `FetchContent_GetProperties` does not retrieve the SOURCE_DIR and BINARY_DIR we need to
+  # parse them and their defaults manually.
   cmake_parse_arguments(${lower_case_name} "" "SOURCE_DIR;BINARY_DIR;SUBBUILD_DIR" "" ${fetch_args})
 
   if(NOT ${lower_case_name}_SOURCE_DIR)

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -865,7 +865,7 @@ function(CPMAddPackage)
     cpm_declare_fetch(
       "${CPM_ARGS_NAME}" "${CPM_ARGS_VERSION}" "${PACKAGE_INFO}" "${CPM_ARGS_UNPARSED_ARGUMENTS}"
     )
-    cpm_fetch_package("${CPM_ARGS_NAME}" populated)
+    cpm_fetch_package("${CPM_ARGS_NAME}" populated "${CPM_ARGS_UNPARSED_ARGUMENTS}")
     if(CPM_SOURCE_CACHE AND download_directory)
       file(LOCK ${download_directory}/../cmake.lock RELEASE)
     endif()
@@ -1056,7 +1056,7 @@ endfunction()
 
 # downloads a previously declared package via FetchContent and exports the variables
 # `${PACKAGE}_SOURCE_DIR` and `${PACKAGE}_BINARY_DIR` to the parent scope
-function(cpm_fetch_package PACKAGE populated)
+function(cpm_fetch_package PACKAGE populated fetch_args)
   set(${populated}
       FALSE
       PARENT_SCOPE
@@ -1072,10 +1072,7 @@ function(cpm_fetch_package PACKAGE populated)
   # with the new `FetchContent_Populate` syntax it seems that SOURCE and BINARY dir variables are no
   # longer retrieved whne using `FetchContent_GetProperties`, so we need to implement the parsing
   # and defaults for these ourselves.
-  cmake_parse_arguments(
-    ${lower_case_name} "" "SOURCE_DIR;BINARY_DIR;SUBBUILD_DIR" "" "${CPM_ARGS_UNPARSED_ARGUMENTS}"
-    ${ARGN}
-  )
+  cmake_parse_arguments(${lower_case_name} "" "SOURCE_DIR;BINARY_DIR;SUBBUILD_DIR" "" ${fetch_args})
 
   if(NOT ${lower_case_name}_SOURCE_DIR)
     set(${lower_case_name}_SOURCE_DIR "${CPM_FETCHCONTENT_BASE_DIR}/${lower_case_name}-src")

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1087,11 +1087,13 @@ function(cpm_fetch_package PACKAGE populated fetch_args)
       BINARY_DIR ${${lower_case_name}_BINARY_DIR}
       "${${lower_case_name}_UNPARSED_ARGUMENTS}"
     )
-    # ensure FetchContent knows the project is populated
-    fetchcontent_setpopulated(
-      ${PACKAGE} SOURCE_DIR ${${lower_case_name}_SOURCE_DIR} BINARY_DIR
-      ${${lower_case_name}_BINARY_DIR}
-    )
+    if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24.0")
+      # ensure FetchContent knows the project is populated
+      fetchcontent_setpopulated(
+        ${PACKAGE} SOURCE_DIR ${${lower_case_name}_SOURCE_DIR} BINARY_DIR
+        ${${lower_case_name}_BINARY_DIR}
+      )
+    endif()
     set(${populated}
         TRUE
         PARENT_SCOPE


### PR DESCRIPTION
My own attempt at figuring out why #570 doesn't seem to satisfy our test cases and trying to understand what the differences between old and new syntax are. For one it seems that `FetchContent_GetProperties` does not seem to give us the SOURCE and BINARY directory, as I would have expected, so we need to implement the parsing ourselves. Now it seems that the handling of git has changed, leading to issues with the relative URL and deleted source dir test cases.