### PR TITLE
doc: warn users that PATCHES may not work properly when CPM_SOURCE_CACHE is unset.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ On the other hand, if `VERSION` hasn't been explicitly specified, CPM can automa
 `GIT_TAG` can also be set to a specific commit or a branch name such as `master`, however this isn't recommended, as such packages will only be updated when the cache is cleared.
 
 `PATCHES` takes a list of patch files to apply sequentially. For a basic example, see [Highway](examples/highway/CMakeLists.txt).
+We recommend that if you use `PATCHES`, you also set `CPM_SOURCE_CACHE`. See [issue 577](https://github.com/cpm-cmake/CPM.cmake/issues/577).
 
 If an additional optional parameter `EXCLUDE_FROM_ALL` is set to a truthy value, then any targets defined inside the dependency won't be built by default. See the [CMake docs](https://cmake.org/cmake/help/latest/prop_tgt/EXCLUDE_FROM_ALL.html) for details.
 


### PR DESCRIPTION
Issue https://github.com/cpm-cmake/CPM.cmake/issues/577 is difficult to debug once triggered given that it is undocumented. It is likely to affect virtually all developers who rely on PATCHES with CPM_SOURCE_CACHE unset. If there is no plan to resolve it quickly, and if the assumption is that the users should set CPM_SOURCE_CACHE when they use PATCHES, then it should be documented as such.

