### PR TITLE
if CPM_LOCAL_PACKAGES_ONLY, make `find_package` fail if it failed to find.

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -300,11 +300,31 @@ function(CPMFindPackage)
     return()
   endif()
 
-  cpm_find_package(${CPM_ARGS_NAME} "${CPM_ARGS_VERSION}" ${CPM_ARGS_FIND_PACKAGE_ARGUMENTS})
+  if(${CPM_USE_LOCAL_PACKAGES})
+    cpm_find_package(${CPM_ARGS_NAME} "${CPM_ARGS_VERSION}" ${CPM_ARGS_FIND_PACKAGE_ARGUMENTS})
 
-  if(NOT CPM_PACKAGE_FOUND)
-    CPMAddPackage(${ARGN})
+    if(CPM_PACKAGE_FOUND)
+      cpm_export_variables(${CPM_ARGS_NAME})
+      return()
+    else()
+      string(replace " " ";" EDITED_CPM_ARGS_FIND_PACKAGE_ARGUMENTS
+                     "${CPM_ARGS_FIND_PACKAGE_ARGUMENTS}"
+      )
+      message(
+        warning
+          "${CPM_INDENT} ${CPM_ARGS_NAME} not found via find_package(${CPM_ARGS_NAME} ${CPM_ARGS_VERSION} ${EDITED_CPM_ARGS_FIND_PACKAGE_ARGUMENTS}). The warning emitted bacause cpm_use_local_packages is set to \"${CPM_USE_LOCAL_PACKAGES}\" . Falling back to downloading the package."
+      )
+      CPMAddPackage(${ARGN})
+      cpm_export_variables(${CPM_ARGS_NAME})
+    endif()
+  endif()
+
+  if(${CPM_LOCAL_PACKAGES_ONLY})
+    cpm_find_package(
+      ${CPM_ARGS_NAME} "${CPM_ARGS_VERSION}" REQUIRED ${CPM_ARGS_FIND_PACKAGE_ARGUMENTS}
+    )
     cpm_export_variables(${CPM_ARGS_NAME})
+    return()
   endif()
 
 endfunction()
@@ -533,7 +553,8 @@ endfunction()
 # method to overwrite internal FetchContent properties, to allow using CPM.cmake to overload
 # FetchContent calls. As these are internal cmake properties, this method should be used carefully
 # and may need modification in future CMake versions. Source:
-# https://github.com/Kitware/CMake/blob/dc3d0b5a0a7d26d43d6cfeb511e224533b5d188f/Modules/FetchContent.cmake #L1152
+# https://github.com/Kitware/CMake/blob/dc3d0b5a0a7d26d43d6cfeb511e224533b5d188f/Modules/FetchContent.cmake
+# #L1152
 function(cpm_override_fetchcontent contentName)
   cmake_parse_arguments(PARSE_ARGV 1 arg "" "SOURCE_DIR;BINARY_DIR" "")
   if(NOT "${arg_UNPARSED_ARGUMENTS}" STREQUAL "")
@@ -716,23 +737,23 @@ function(CPMAddPackage)
   endif()
 
   if(NOT CPM_ARGS_FORCE)
-    if(CPM_USE_LOCAL_PACKAGES)
+    if(${CPM_USE_LOCAL_PACKAGES})
       cpm_find_package(${CPM_ARGS_NAME} "${CPM_ARGS_VERSION}" ${CPM_ARGS_FIND_PACKAGE_ARGUMENTS})
 
       if(CPM_PACKAGE_FOUND)
         cpm_export_variables(${CPM_ARGS_NAME})
         return()
       else()
-        string(REPLACE " " ";" EDITED_CPM_ARGS_FIND_PACKAGE_ARGUMENTS
+        string(replace " " ";" EDITED_CPM_ARGS_FIND_PACKAGE_ARGUMENTS
                        "${CPM_ARGS_FIND_PACKAGE_ARGUMENTS}"
         )
         message(
-          WARNING
+          warning
             "${CPM_INDENT} ${CPM_ARGS_NAME} not found via find_package(${CPM_ARGS_NAME} ${CPM_ARGS_VERSION} ${EDITED_CPM_ARGS_FIND_PACKAGE_ARGUMENTS}). The warning emitted bacause CPM_USE_LOCAL_PACKAGES is set to \"${CPM_USE_LOCAL_PACKAGES}\" . Falling back to downloading the package."
         )
       endif()
     endif()
-    if(CPM_LOCAL_PACKAGES_ONLY)
+    if(${CPM_LOCAL_PACKAGES_ONLY})
       cpm_find_package(
         ${CPM_ARGS_NAME} "${CPM_ARGS_VERSION}" REQUIRED ${CPM_ARGS_FIND_PACKAGE_ARGUMENTS}
       )


### PR DESCRIPTION
I've found that if using CPM_LOCAL_PACKAGES_ONLY , it will make `message(SEND_ERROR ...)` about failure.

https://cmake.org/cmake/help/latest/command/message.html

1. `message(SEND_ERROR ...)` not fails immediately, which makes CPM go further and download the package, though not allowing to generate
2. It doesn't show error generated by `find_package` .


Firstly I thought to change `message(SEND_ERROR ...` to `message(FATAL_ERROR ...)`

But my real problem was that `find_package` have found a package with specified version, but not some of its components. 

IDK how to get error message from `find_package`, that's why I've made that if CPM_LOCAL_PACKAGES_ONLY to just ask `find_package` to fail if it failed, and show its error logs by itself. And that's just by adding `REQUIRED` .