### PR TITLE
Add find_package overrides that also work in CONFIG mode (#498)

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,13 @@ In the case that `find_package` requires additional arguments, the parameter `FI
 
 Note that this does not apply to dependencies that have been defined with a truthy `FORCE` parameter. These will be added as defined.
 
+### CPM_DONT_UPDATE_MODULE_PATH
+
+By default, CPM will override any `find_package` commands to use the CPM downloaded version.
+This is equivalent to the `OVERRIDE_FIND_PACKAGE` FetchContent option, which has no effect in CPM.
+To disable this behaviour set the `CPM_DONT_UPDATE_MODULE_PATH` option.
+This will not work for `find_package(CONFIG)` in CMake versions before 3.24.
+
 ### CPM_USE_NAMED_CACHE_DIRECTORIES
 
 If set, CPM use additional directory level in cache to improve readability of packages names in IDEs like CLion. It changes cache structure, so all dependencies are downloaded again. There is no problem to mix both structures in one cache directory but then there may be 2 copies of some dependencies.

--- a/test/integration/test_basics.rb
+++ b/test/integration/test_basics.rb
@@ -31,7 +31,9 @@ class Basics < IntegrationTest
     assert_same_path File.join(prj.bin_dir, 'cpm-package-lock.cmake'), check_and_get('CPM_PACKAGE_LOCK_FILE')
 
     assert_equal 'OFF', check_and_get('CPM_DONT_UPDATE_MODULE_PATH', 'BOOL')
-    assert_same_path File.join(prj.bin_dir, 'CPM_modules'), check_and_get('CPM_MODULE_PATH')
+    if @cache.entries['CMAKE_FIND_PACKAGE_REDIRECTS_DIR'].nil?
+      assert_same_path File.join(prj.bin_dir, 'CPM_modules'), check_and_get('CPM_MODULE_PATH')
+    end
   end
 
   # Test when env CPM_SOURCE_CACHE is set

--- a/test/unit/local_dependency/ModuleCMakeLists.txt.in
+++ b/test/unit/local_dependency/ModuleCMakeLists.txt.in
@@ -8,6 +8,10 @@ option(ENABLE_TEST_COVERAGE "Enable test coverage" OFF)
 
 # ---- Dependencies ----
 
+if (@TEST_FORCE_MODULE_MODE@)
+  unset(CMAKE_FIND_PACKAGE_REDIRECTS_DIR CACHE)
+endif()
+
 include(@CPM_PATH@/CPM.cmake)
 
 CPMAddPackage(
@@ -15,21 +19,23 @@ CPMAddPackage(
   SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/dependency
 )
 
-# ---- check if generated modules override find_package ----
-
-if (@test_check_find_package@)
-  find_package(@TEST_DEPENDENCY_NAME@ REQUIRED)
-endif()
-
 # ---- Call dependency method to validate correct addition of directory ----
 
 dependency_function()
 
-# ---- Check parameters ----
-
+# ---- Check newly added ----
 include(@CPM_PATH@/testing.cmake)
-
 ASSERT_TRUTHY(@TEST_DEPENDENCY_NAME@_ADDED)
+
+# ---- Check if generated modules override find_package ----
+
+if (@TEST_FIND_PACKAGE@)
+  find_package(@TEST_DEPENDENCY_NAME@ @TEST_FIND_PACKAGE_CONFIG@ REQUIRED)
+  find_package(@TEST_CANT_FIND_PACKAGE_NAME@ @TEST_FIND_PACKAGE_CONFIG@ QUIET)
+  ASSERT_FALSY(@TEST_CANT_FIND_PACKAGE_NAME@_FOUND)
+endif()
+
+# ---- Check parameters ----
 ASSERT_DEFINED(@TEST_DEPENDENCY_NAME@_SOURCE_DIR)
 ASSERT_DEFINED(@TEST_DEPENDENCY_NAME@_BINARY_DIR)
 ASSERT_EQUAL("${CPM_LAST_PACKAGE_NAME}" "@TEST_DEPENDENCY_NAME@")

--- a/test/unit/modules.cmake
+++ b/test/unit/modules.cmake
@@ -3,7 +3,8 @@ include(${CPM_PATH}/testing.cmake)
 
 set(TEST_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/modules)
 
-function(init_project_with_dependency TEST_DEPENDENCY_NAME)
+function(init_project_with_dependency TEST_DEPENDENCY_NAME TEST_CANT_FIND_PACKAGE_NAME)
+  set(TEST_FIND_PACKAGE ON)
   configure_package_config_file(
     "${CMAKE_CURRENT_LIST_DIR}/local_dependency/ModuleCMakeLists.txt.in"
     "${CMAKE_CURRENT_LIST_DIR}/local_dependency/CMakeLists.txt"
@@ -18,11 +19,17 @@ function(init_project_with_dependency TEST_DEPENDENCY_NAME)
   assert_equal(${ret} "0")
 endfunction()
 
-init_project_with_dependency(A)
-assert_exists(${TEST_BUILD_DIR}/CPM_modules)
-assert_exists(${TEST_BUILD_DIR}/CPM_modules/FindA.cmake)
-assert_not_exists(${TEST_BUILD_DIR}/CPM_modules/FindB.cmake)
+init_project_with_dependency(A B)
+init_project_with_dependency(B A)
 
-init_project_with_dependency(B)
-assert_not_exists(${TEST_BUILD_DIR}/CPM_modules/FindA.cmake)
-assert_exists(${TEST_BUILD_DIR}/CPM_modules/FindB.cmake)
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24.0")
+  set(TEST_FIND_PACKAGE_CONFIG CONFIG)
+  init_project_with_dependency(A B)
+  init_project_with_dependency(B A)
+
+  # Test the fallback path for CMake <3.24 works
+  set(TEST_FIND_PACKAGE_CONFIG)
+  set(TEST_FORCE_MODULE_MODE ON)
+  init_project_with_dependency(A B)
+  init_project_with_dependency(B A)
+endif()


### PR DESCRIPTION
CPM currently adds a FindFoo.cmake to the module path to override subsequent find_package calls. This makes sure that works when the find_package call is in CONFIG mode as well. Some of my dependencies use this in their CMakeLists.txt. This is equivalent to the OVERRIDE_FIND_PACKAGE argument to FetchContent, we could add that option to CPMAddPackage, but it seems like this is the intended default behaviour of CPM?

The include(....-extra.cmake) bits are something FetchContent does that's also useful here. They should maybe be added to the Find*.cmake version too?

Fixes #498 