### PR TITLE
updated asio_standalone example

### DIFF
--- a/examples/asio-standalone/CMakeLists.txt
+++ b/examples/asio-standalone/CMakeLists.txt
@@ -8,7 +8,7 @@ include(../../cmake/CPM.cmake)
 
 find_package(Threads REQUIRED)
 
-CPMAddPackage("gh:chriskohlhoff/asio#asio-1-18-1@1.18.1")
+CPMAddPackage("gh:chriskohlhoff/asio#asio-1-32-0@1.32.0")
 
 # ASIO doesn't use CMake, we have to configure it manually. Extra notes for using on Windows:
 #


### PR DESCRIPTION
updated the example to the latest version tag as the 1-18-1 is broken due to a missing the include for the <utility> header