### PR TITLE
CPM.cmake redundant return() removed

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -59,7 +59,6 @@ See https://github.com/cpm-cmake/CPM.cmake for more information."
     if(${CMAKE_VERSION} VERSION_LESS "3.17.0")
       include(FetchContent)
     endif()
-    return()
   endif()
 
   get_property(


### PR DESCRIPTION
CPM can work, but this return stop to loading script and functions are unavailable.