### PR TITLE
Update Boost example to v1.87.0

### DIFF
--- a/examples/boost/CMakeLists.txt
+++ b/examples/boost/CMakeLists.txt
@@ -1,24 +1,61 @@
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.14...3.31 FATAL_ERROR)
 
-project(CPMExampleBoost)
+project(CPMExampleBoost LANGUAGES CXX)
 
 # ---- Create binary ----
 
-add_executable(CPMExampleBoost main.cpp)
+add_library(CPMExampleBoost main.cpp)
 target_compile_features(CPMExampleBoost PRIVATE cxx_std_17)
 
 # ---- Dependencies ----
 
+set(env{CPM_USE_LOCAL_PACKAGES} OFF)
+
 include(../../cmake/CPM.cmake)
+
+set(CMAKE_SKIP_INSTALL_RULES OFF)
+set(CMAKE_INSTALL_MESSAGE LAZY)
+set(CMAKE_UNITY_BUILD ON)
+
+
+set(BOOST_VERSION 1.87.0)
+list(APPEND BOOST_INCLUDE_LIBRARIES asio container)
+
+set(BUILD_SHARED_LIBS ON)
 
 CPMAddPackage(
   NAME Boost
-  VERSION 1.86.0 # Versions less than 1.85.0 may need patches for installation targets.
-  URL https://github.com/boostorg/boost/releases/download/boost-1.86.0/boost-1.86.0-cmake.tar.xz
-  URL_HASH SHA256=2c5ec5edcdff47ff55e27ed9560b0a0b94b07bd07ed9928b476150e16b0efc57
-  OPTIONS "BOOST_ENABLE_CMAKE ON" "BOOST_SKIP_INSTALL_RULES ON" # Set `OFF` for installation
-          "BUILD_SHARED_LIBS OFF" "BOOST_INCLUDE_LIBRARIES container\\\;asio" # Note the escapes!
+  VERSION ${BOOST_VERSION}
+  URL https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}-cmake.tar.xz
+  URL_HASH SHA256=7da75f171837577a52bbf217e17f8ea576c7c246e4594d617bfde7fafd408be5
+  EXCLUDE_FROM_ALL ON
+  SYSTEM ON
+  OPTIONS "BOOST_ENABLE_CMAKE ON" "BOOST_SKIP_INSTALL_RULES ${CMAKE_SKIP_INSTALL_RULES}"
 )
 
 # `Boost::headers` is also valid
-target_link_libraries(CPMExampleBoost PRIVATE Boost::asio Boost::container)
+target_link_libraries(CPMExampleBoost PUBLIC Boost::asio Boost::container)
+
+if(CMAKE_SKIP_INSTALL_RULES)
+  return()
+endif()
+
+# ---- Install rules ----
+
+CPMAddPackage("gh:TheLartians/PackageProject.cmake@1.11.0")
+
+packageProject(
+  NAME CPMExampleBoost
+  TARGETS CPMExampleBoost
+  VERSION ${BOOST_VERSION}
+  NAMESPACE BoostExample
+  BINARY_DIR ${PROJECT_BINARY_DIR}
+  ARCH_INDEPENDENT NO
+  # INCLUDE_DIR ${BOOST_SOURCE}/boost
+  # INCLUDE_DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/boost
+  # INCLUDE_HEADER_REGEX [=[.*\.(inc|h|hpp|ipp)$]=]
+  DISABLE_VERSION_SUFFIX YES
+  COMPATIBILITY SameMajorVersion
+  DEPENDENCIES "Boost ${BOOST_VERSION}"
+  CPACK YES
+)

--- a/examples/boost/CMakeLists.txt
+++ b/examples/boost/CMakeLists.txt
@@ -17,7 +17,6 @@ set(CMAKE_SKIP_INSTALL_RULES OFF)
 set(CMAKE_INSTALL_MESSAGE LAZY)
 set(CMAKE_UNITY_BUILD ON)
 
-
 set(BOOST_VERSION 1.87.0)
 list(APPEND BOOST_INCLUDE_LIBRARIES asio container)
 
@@ -42,18 +41,16 @@ endif()
 
 # ---- Install rules ----
 
-CPMAddPackage("gh:TheLartians/PackageProject.cmake@1.11.0")
+CPMAddPackage("gh:TheLartians/PackageProject.cmake@1.13.0")
 
 packageProject(
-  NAME CPMExampleBoost
-  TARGETS CPMExampleBoost
+  NAME CPMExampleBoost TARGETS CPMExampleBoost
   VERSION ${BOOST_VERSION}
   NAMESPACE BoostExample
   BINARY_DIR ${PROJECT_BINARY_DIR}
-  ARCH_INDEPENDENT NO
-  # INCLUDE_DIR ${BOOST_SOURCE}/boost
-  # INCLUDE_DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/boost
-  # INCLUDE_HEADER_REGEX [=[.*\.(inc|h|hpp|ipp)$]=]
+             ARCH_INDEPENDENT NO
+             # INCLUDE_DIR ${BOOST_SOURCE}/boost INCLUDE_DESTINATION
+             # ${CMAKE_INSTALL_INCLUDEDIR}/boost INCLUDE_HEADER_REGEX [=[.*\.(inc|h|hpp|ipp)$]=]
   DISABLE_VERSION_SUFFIX YES
   COMPATIBILITY SameMajorVersion
   DEPENDENCIES "Boost ${BOOST_VERSION}"

--- a/examples/boost/main.cpp
+++ b/examples/boost/main.cpp
@@ -21,7 +21,7 @@ void print(const boost::system::error_code& /*e*/) {
 }
 
 int main() {
-  boost::asio::io_service io;
+  boost::asio::io_context io;
 
   strings.push_back("Hello, world!\n");
 


### PR DESCRIPTION
Fix compile errors and make the code more flexible.

Use `packageProject` to install the example lib with its dependencies.