### PR TITLE
Investigate sol2 CI build issue

### DIFF
--- a/examples/sol2/CMakeLists.txt
+++ b/examples/sol2/CMakeLists.txt
@@ -8,7 +8,7 @@ include(../../cmake/CPM.cmake)
 
 CPMAddPackage(
   NAME lua
-  GIT_REPOSITORY https://github.com/lua/lua.git
+  GITHUB_REPOSITORY lua/lua
   VERSION 5.3.5
   DOWNLOAD_ONLY YES
 )
@@ -21,7 +21,13 @@ if(lua_ADDED)
   target_include_directories(lua SYSTEM PUBLIC $<BUILD_INTERFACE:${lua_SOURCE_DIR}>)
 endif()
 
-CPMAddPackage("gh:ThePhD/sol2@3.3.0")
+CPMAddPackage(
+  NAME sol2
+  GITHUB_REPOSITORY ThePhD/sol2
+  VERSION 3.3.0
+  # https://github.com/ThePhD/sol2/issues/1581#issuecomment-2103463524
+  PATCHES fix_for_clang.patch
+)
 
 # ---- Executable ----
 

--- a/examples/sol2/CMakeLists.txt
+++ b/examples/sol2/CMakeLists.txt
@@ -25,8 +25,7 @@ CPMAddPackage(
   NAME sol2
   GITHUB_REPOSITORY ThePhD/sol2
   VERSION 3.3.0
-  # fix for clang 18.1.0, see
-  # https://github.com/ThePhD/sol2/issues/1581#issuecomment-2103463524
+  # fix for clang 18.1.0, see https://github.com/ThePhD/sol2/issues/1581#issuecomment-2103463524
   PATCHES fix_for_clang.patch
 )
 

--- a/examples/sol2/CMakeLists.txt
+++ b/examples/sol2/CMakeLists.txt
@@ -25,6 +25,7 @@ CPMAddPackage(
   NAME sol2
   GITHUB_REPOSITORY ThePhD/sol2
   VERSION 3.3.0
+  # fix for clang 18.1.0, see
   # https://github.com/ThePhD/sol2/issues/1581#issuecomment-2103463524
   PATCHES fix_for_clang.patch
 )

--- a/examples/sol2/fix_for_clang.patch
+++ b/examples/sol2/fix_for_clang.patch
@@ -1,24 +1,9 @@
 Common subdirectories: a/.bcr and b/.bcr
 Common subdirectories: a/.github and b/.github
-diff --git a/sol/sol.hpp b/sol/sol.hpp index 8b0b7d36ea4ef..1a9375d996d2f 100644
---- a/sol/sol.hpp
-+++ b/sol/sol.hpp
-@@ -19416,7 +19416,13 @@ namespace sol { namespace function_detail {
- 		}
- 
- 		template <bool is_yielding, bool no_trampoline>
--		static int call(lua_State* L) noexcept(std::is_nothrow_copy_assignable_v<T>) {
-+		static int call(lua_State* L)
-+#if SOL_IS_ON(SOL_COMPILER_CLANG)
-+		// apparent regression in clang 18 - llvm/llvm-project#91362
-+#else
-+			noexcept(std::is_nothrow_copy_assignable_v<T>)
-+#endif
-+		{
- 			int nr;
- 			if constexpr (no_trampoline) {
- 				nr = real_call(L);
-@@ -19456,7 +19462,13 @@ namespace sol { namespace function_detail {
+diff -u a/include/sol/function_types_stateless.hpp b/include/types/function_types_stateless.hpp
+--- a/include/sol/function_types_stateless.hpp
++++ b/include/sol/function_types_stateless.hpp
+@@ -322,7 +322,13 @@ namespace sol { namespace function_detail {
  		}
  
  		template <bool is_yielding, bool no_trampoline>

--- a/examples/sol2/fix_for_clang.patch
+++ b/examples/sol2/fix_for_clang.patch
@@ -1,0 +1,35 @@
+Common subdirectories: a/.bcr and b/.bcr
+Common subdirectories: a/.github and b/.github
+diff --git a/sol/sol.hpp b/sol/sol.hpp index 8b0b7d36ea4ef..1a9375d996d2f 100644
+--- a/sol/sol.hpp
++++ b/sol/sol.hpp
+@@ -19416,7 +19416,13 @@ namespace sol { namespace function_detail {
+ 		}
+ 
+ 		template <bool is_yielding, bool no_trampoline>
+-		static int call(lua_State* L) noexcept(std::is_nothrow_copy_assignable_v<T>) {
++		static int call(lua_State* L)
++#if SOL_IS_ON(SOL_COMPILER_CLANG)
++		// apparent regression in clang 18 - llvm/llvm-project#91362
++#else
++			noexcept(std::is_nothrow_copy_assignable_v<T>)
++#endif
++		{
+ 			int nr;
+ 			if constexpr (no_trampoline) {
+ 				nr = real_call(L);
+@@ -19456,7 +19462,13 @@ namespace sol { namespace function_detail {
+ 		}
+ 
+ 		template <bool is_yielding, bool no_trampoline>
+-		static int call(lua_State* L) noexcept(std::is_nothrow_copy_assignable_v<T>) {
++		static int call(lua_State* L)
++#if SOL_IS_ON(SOL_COMPILER_CLANG)
++		// apparent regression in clang 18 - llvm/llvm-project#91362
++#else
++			noexcept(std::is_nothrow_copy_assignable_v<T>)
++#endif
++		{
+ 			int nr;
+ 			if constexpr (no_trampoline) {
+ 				nr = real_call(L);

--- a/examples/sol2/fix_for_clang.patch
+++ b/examples/sol2/fix_for_clang.patch
@@ -1,5 +1,3 @@
-Common subdirectories: a/.bcr and b/.bcr
-Common subdirectories: a/.github and b/.github
 diff -u a/include/sol/function_types_stateless.hpp b/include/types/function_types_stateless.hpp
 --- a/include/sol/function_types_stateless.hpp
 +++ b/include/sol/function_types_stateless.hpp


### PR DESCRIPTION
In seems that clang 18.1.0 creates an issue with sol2, leading to compilation errors. This PR adds a patch taken from https://github.com/ThePhD/sol2/issues/1581#issuecomment-2103463524 that fixes the issue.