### PR TITLE
do not generate module files with DOWNLOAD_ONLY

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -867,7 +867,9 @@ function(CPMAddPackage)
     endif()
   endif()
 
-  cpm_create_module_file(${CPM_ARGS_NAME} "CPMAddPackage(\"${ARGN}\")")
+  if(NOT "${DOWNLOAD_ONLY}")
+    cpm_create_module_file(${CPM_ARGS_NAME} "CPMAddPackage(\"${ARGN}\")")
+  endif()
 
   if(CPM_PACKAGE_LOCK_ENABLED)
     if((CPM_ARGS_VERSION AND NOT CPM_ARGS_SOURCE_DIR) OR CPM_INCLUDE_ALL_IN_PACKAGE_LOCK)


### PR DESCRIPTION
Resolves #649

Prevents calling `cpm_create_module_file` when `DOWNLOAD_ONLY` was set to true. 
I see no reason to generate module files, when you're just downloading a dependency.
