### PR TITLE
fix the warning CPM: Your project is using an unstable development version of CPM.cmake. when using FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git/")
   find_package(Git REQUIRED)
   execute_process(
-    COMMAND "${GIT_EXECUTABLE}" describe --tags --match=?[0-9.]*
+    COMMAND "${GIT_EXECUTABLE}" describe --tags --long
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     OUTPUT_VARIABLE DESCRIBE_NAME COMMAND_ERROR_IS_FATAL ANY
   )
-  set(CPM_DEVELOPMENT "-development-version")
+  string(STRIP ${DESCRIBE_NAME} DESCRIBE_NAME)
+  string(REGEX MATCH "v[0-9]*.[0-9]*.[0-9]*\-0\-[a-zA-Z0-9]*" DESCRIBE_NAME ${DESCRIBE_NAME})
+  if(DESCRIBE_NAME STREQUAL "")
+    set(CPM_DEVELOPMENT "-development-version")
+  endif()
 else()
   file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/.git_archival.txt" DESCRIBE_NAME
        REGEX "^describe-name:.*"


### PR DESCRIPTION
This PR fix the warning 
```bash
CMake Warning at build/_deps/cpm-src/cmake/CPM.cmake:80 (message):
  CPM: Your project is using an unstable development version of CPM.cmake.
  Please update to a recent release if possible.  See
  https://github.com/cpm-cmake/CPM.cmake for details.
Call Stack (most recent call first):
  build/_deps/cpm-src/CMakeLists.txt:37 (include)
```

when using FetchContent to download CPM.

describe --tags --long command : 
Always output the long format (the tag, the number of commits and the abbreviated commit name) even when it matches a tag. This is useful when you want to see parts of the commit object name in "describe" output, even when the commit in question happens to be a tagged version. Instead of just emitting the tag name, it will describe such a commit as v1.2-0-gdeadbee (0th commit since tag v1.2 that points at object deadbee…​.).
 
so if the HEAD is exactly at some tags matching v*.*.*-0-* then Head is on a release and so not a development.
