### PR TITLE
Allow users to override the default path for CPM_SOURCE_CACHE

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -155,7 +155,10 @@ set(CPM_DRY_RUN
     CACHE INTERNAL "Don't download or configure dependencies (for testing)"
 )
 
-if(DEFINED ENV{CPM_SOURCE_CACHE} AND NOT DEFINED CPM_SOURCE_CACHE_DEFAULT)
+# ENV gets top priority to control CPM_SOURCE_CACHE location
+# If it is not defined, allow user to control the location with CPM_SOURCE_CACHE_DEFAULT
+# If neither are set disable CPM_SOURCE_CACHE
+if(DEFINED ENV{CPM_SOURCE_CACHE})
   set(CPM_SOURCE_CACHE_DEFAULT $ENV{CPM_SOURCE_CACHE})
 elseif(NOT DEFINED CPM_SOURCE_CACHE_DEFAULT)
   set(CPM_SOURCE_CACHE_DEFAULT OFF)


### PR DESCRIPTION
Currently, only the ENV CPM_SOURCE_CACHE can be used for steering CPM download caching.

However, I am not a fan of environment variable engineering, (We have too much of it already in our code base).

With this change, a user of CPM can first set CPM_SOURCE_CACHE_DEFAULT, and have that be respected by CPM.cmake.