### PR TITLE
Add support for GIT_SUBMODULES argument

### DIFF
--- a/cmake/.cmake-format-additional_commands-cpm
+++ b/cmake/.cmake-format-additional_commands-cpm
@@ -21,6 +21,7 @@ parse:
         FIND_PACKAGE_ARGUMENTS: 1
         NO_CACHE: 1
         GIT_SHALLOW: 1
+        GIT_SUBMODULES: 1
         URL: 1
         URL_HASH: 1
         URL_MD5: 1

--- a/test/integration/test_fetchcontent_compatibility.rb
+++ b/test/integration/test_fetchcontent_compatibility.rb
@@ -40,4 +40,69 @@ class FetchContentCompatibility < IntegrationTest
     assert_success prj.build
   end
 
+  def test_submodules_not_cloned_when_git_submodules_empty
+    prj = make_project from_template: 'using-adder'
+
+    prj.create_lists_from_default_template package: <<~PACK
+      CPMAddPackage(
+        NAME testpack-adder
+        GITHUB_REPOSITORY gillamkid/testpack-adder
+        GIT_TAG f154cd373f2eefba715ca765892bb1c788a5f065
+        GIT_SUBMODULES ""
+      )
+
+      # should have no effect, as we added the dependency using CPM
+      FetchContent_Declare(
+        testpack-adder
+        GIT_REPOSITORY https://github.com/gillamkid/testpack-adder
+        GIT_TAG f154cd373f2eefba715ca765892bb1c788a5f065
+      )
+      FetchContent_MakeAvailable(testpack-adder)
+    PACK
+
+    # configure with unpopulated cache
+    assert_success prj.configure
+    assert_success prj.build
+
+    # check the correct repo/branch was cloned
+    submodule_container_readme = File.join(prj.build_dir, '_deps', 'testpack-adder-src', 'submodules', 'README.md')
+    assert_true File.exist?(submodule_container_readme)
+
+    # check recursive cloning of submodules did NOT happen
+    submodule_file = File.join(prj.build_dir, '_deps', 'testpack-adder-src', 'submodules', 'tinySubmodule', 'README.md')
+    assert_false File.exist?(submodule_file)
+  end
+
+  def test_submodules_cloned_recursively_by_default
+    prj = make_project from_template: 'using-adder'
+
+    prj.create_lists_from_default_template package: <<~PACK
+      CPMAddPackage(
+        NAME testpack-adder
+        GITHUB_REPOSITORY gillamkid/testpack-adder
+        GIT_TAG f154cd373f2eefba715ca765892bb1c788a5f065
+      )
+
+      # should have no effect, as we added the dependency using CPM
+      FetchContent_Declare(
+        testpack-adder
+        GIT_REPOSITORY https://github.com/gillamkid/testpack-adder
+        GIT_TAG f154cd373f2eefba715ca765892bb1c788a5f065
+      )
+      FetchContent_MakeAvailable(testpack-adder)
+    PACK
+
+    # configure with unpopulated cache
+    assert_success prj.configure
+    assert_success prj.build
+
+    # check the correct repo/branch was cloned
+    submodule_container_readme = File.join(prj.build_dir, '_deps', 'testpack-adder-src', 'submodules', 'README.md')
+    assert_true File.exist?(submodule_container_readme)
+
+    # check recursive cloning of submodules happened
+    submodule_file = File.join(prj.build_dir, '_deps', 'testpack-adder-src', 'submodules', 'tinySubmodule', 'README.md')
+    assert_true File.exist?(submodule_file)
+  end
+
 end


### PR DESCRIPTION
CPM does passthrough for many of the argument options of cmake's `FetchContent()` function. Hwever, there was an argument of interest that it was not passing: `GIT_SUBMODULES`.

`GIT_SUBMODULES` is needed if you want to use `CPMAddPackage()` and have it not initialize the submodules of the repo. 

I added support so `GIT_SUBMODULES ""` can be used to prevent submodules from being initialized the same way it is used to do so when calling `FetchContent()` directly.