### PR TITLE
fix: PATCHES command when using package-lock

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1387,6 +1387,11 @@ function(cpm_prettify_package_arguments OUT_VAR IS_IN_COMMENT)
       if(${IS_IN_COMMENT})
         string(APPEND PRETTY_OUT_VAR "#")
       endif()
+      if(${oneArgName} STREQUAL "SOURCE_DIR")
+        string(REPLACE ${CMAKE_SOURCE_DIR} "\${CMAKE_SOURCE_DIR}" CPM_ARGS_${oneArgName}
+                       ${CPM_ARGS_${oneArgName}}
+        )
+      endif()
       string(APPEND PRETTY_OUT_VAR "  ${oneArgName} ${CPM_ARGS_${oneArgName}}\n")
     endif()
   endforeach()

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -112,6 +112,62 @@ macro(cpm_set_policies)
 endmacro()
 cpm_set_policies()
 
+macro(cpm_generate_apply_patches_script)
+  set(_cpm_patch_script "${CPM_CURRENT_DIRECTORY}/cpm_apply_patches.cmake")
+
+  file(
+    WRITE "${_cpm_patch_script}"
+    [=[
+# Auto-generated patch application script
+separate_arguments(PATCH_FILES)
+
+foreach(patch_file IN LISTS PATCH_FILES)
+  message(STATUS "Checking patch: ${patch_file}")
+
+  execute_process(
+    COMMAND "${PATCH_EXECUTABLE}" --dry-run -p1
+    INPUT_FILE "${patch_file}"
+    RESULT_VARIABLE dry_run_result
+    OUTPUT_VARIABLE dry_out
+    ERROR_VARIABLE dry_err
+  )
+
+  if(dry_run_result EQUAL 0)
+    message(STATUS "Applying patch: ${patch_file}")
+    execute_process(
+      COMMAND "${PATCH_EXECUTABLE}" -p1
+      INPUT_FILE "${patch_file}"
+      RESULT_VARIABLE apply_result
+      OUTPUT_VARIABLE apply_out
+      ERROR_VARIABLE apply_err
+    )
+    if(apply_result EQUAL 0)
+      message(STATUS "Applied patch: ${patch_file}")
+    else()
+      message(FATAL_ERROR "Patch failed: ${patch_file}\n${apply_err}")
+    endif()
+  else()
+    execute_process(
+      COMMAND "${PATCH_EXECUTABLE}" --dry-run -p1 --reverse
+      INPUT_FILE "${patch_file}"
+      RESULT_VARIABLE reverse_result
+      OUTPUT_VARIABLE reverse_out
+      ERROR_VARIABLE reverse_err
+    )
+    if(reverse_result EQUAL 0)
+      message(STATUS "Patch already applied: ${patch_file}")
+    else()
+      message(
+        FATAL_ERROR "Patch cannot be applied and is not already applied: ${patch_file}\n${dry_err}"
+      )
+    endif()
+  endif()
+endforeach()
+]=]
+  )
+endmacro()
+cpm_generate_apply_patches_script()
+
 option(CPM_USE_LOCAL_PACKAGES "Always try to use `find_package` to get dependencies"
        $ENV{CPM_USE_LOCAL_PACKAGES}
 )
@@ -566,41 +622,43 @@ function(cpm_add_patches)
     message(FATAL_ERROR "Couldn't find `patch` executable to use with PATCHES keyword.")
   endif()
 
-  # Create a temporary
-  set(temp_list ${CPM_ARGS_UNPARSED_ARGUMENTS})
+  # -----------------------------------------------------------------------------------------------
+  # Resolve and validate all patch file paths
+  # -----------------------------------------------------------------------------------------------
+  set(resolved_patch_files)
 
-  # Ensure each file exists (or error out) and add it to the list.
-  set(first_item True)
-  foreach(PATCH_FILE ${ARGN})
+  # Allow for generator expressions in patch file paths
+  string(CONFIGURE "${ARGN}" ARGN)
+
+  foreach(PATCH_FILE IN LISTS ARGN)
     # Make sure the patch file exists, if we can't find it, try again in the current directory.
-    if(NOT EXISTS "${PATCH_FILE}")
-      if(NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/${PATCH_FILE}")
+    if(NOT EXISTS ${PATCH_FILE})
+      set(_fallback_path "${PROJECT_SOURCE_DIR}/${PATCH_FILE}")
+      if(NOT EXISTS "${_fallback_path}")
         message(FATAL_ERROR "Couldn't find patch file: '${PATCH_FILE}'")
       endif()
-      set(PATCH_FILE "${CMAKE_CURRENT_LIST_DIR}/${PATCH_FILE}")
+      set(PATCH_FILE "${_fallback_path}")
     endif()
 
     # Convert to absolute path for use with patch file command.
     get_filename_component(PATCH_FILE "${PATCH_FILE}" ABSOLUTE)
-
-    # The first patch entry must be preceded by "PATCH_COMMAND" while the following items are
-    # preceded by "&&".
-    if(first_item)
-      set(first_item False)
-      list(APPEND temp_list "PATCH_COMMAND")
-    else()
-      list(APPEND temp_list "&&")
-    endif()
-    # Add the patch command to the list
-    list(APPEND temp_list "${PATCH_EXECUTABLE}" "-p1" "<" "${PATCH_FILE}")
+    list(APPEND resolved_patch_files "${PATCH_FILE}")
   endforeach()
 
-  # Move temp out into parent scope.
-  set(CPM_ARGS_UNPARSED_ARGUMENTS
-      ${temp_list}
-      PARENT_SCOPE
+  # -----------------------------------------------------------------------------------------------
+  # Construct the patch command
+  # -----------------------------------------------------------------------------------------------
+  string(JOIN " " joined_patch_files ${resolved_patch_files})
+
+  set(_patch_command cmake -D "PATCH_FILES=${joined_patch_files}" -D
+                     "PATCH_EXECUTABLE=${PATCH_EXECUTABLE}" -P "${_cpm_patch_script}"
   )
 
+  list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS PATCH_COMMAND ${_patch_command})
+  set(CPM_ARGS_UNPARSED_ARGUMENTS
+      "${CPM_ARGS_UNPARSED_ARGUMENTS}"
+      PARENT_SCOPE
+  )
 endfunction()
 
 # method to overwrite internal FetchContent properties, to allow using CPM.cmake to overload
@@ -1039,11 +1097,14 @@ endmacro()
 
 # declares a package, so that any call to CPMAddPackage for the package name will use these
 # arguments instead. Previous declarations will not be overridden.
-macro(CPMDeclarePackage Name)
+function(CPMDeclarePackage Name)
   if(NOT DEFINED "CPM_DECLARATION_${Name}")
-    set("CPM_DECLARATION_${Name}" "${ARGN}")
+    set("CPM_DECLARATION_${Name}"
+        "${ARGN}"
+        PARENT_SCOPE
+    )
   endif()
-endmacro()
+endfunction()
 
 function(cpm_add_to_package_lock Name)
   if(NOT CPM_DONT_CREATE_PACKAGE_LOCK)
@@ -1313,18 +1374,15 @@ function(cpm_prettify_package_arguments OUT_VAR IS_IN_COMMENT)
       EXCLUDE_FROM_ALL
       SOURCE_SUBDIR
   )
-  set(multiValueArgs URL OPTIONS DOWNLOAD_COMMAND)
+  set(multiValueArgs URL OPTIONS DOWNLOAD_COMMAND PATCHES)
   cmake_parse_arguments(CPM_ARGS "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  string(TOLOWER "${PROJECT_NAME}" CPM_PROJECT_NAME)
 
   foreach(oneArgName ${oneValueArgs})
     if(DEFINED CPM_ARGS_${oneArgName})
       if(${IS_IN_COMMENT})
         string(APPEND PRETTY_OUT_VAR "#")
-      endif()
-      if(${oneArgName} STREQUAL "SOURCE_DIR")
-        string(REPLACE ${CMAKE_SOURCE_DIR} "\${CMAKE_SOURCE_DIR}" CPM_ARGS_${oneArgName}
-                       ${CPM_ARGS_${oneArgName}}
-        )
       endif()
       string(APPEND PRETTY_OUT_VAR "  ${oneArgName} ${CPM_ARGS_${oneArgName}}\n")
     endif()
@@ -1338,6 +1396,23 @@ function(cpm_prettify_package_arguments OUT_VAR IS_IN_COMMENT)
       foreach(singleOption ${CPM_ARGS_${multiArgName}})
         if(${IS_IN_COMMENT})
           string(APPEND PRETTY_OUT_VAR "#")
+        endif()
+        if(${multiArgName} STREQUAL "PATCHES")
+          # Check if the path contains a "${[NAME]_SOURCE_DIR}" variable, if it does not, issue a
+          # warning a an prepend the PROJECT_SOURCE_DIR to make sure the path is correct. Else this
+          # would lead to huge issues in other projects using this package as dependency, as the
+          # patch file would not be found.
+          if(NOT singleOption MATCHES "\\$\\{${CPM_PROJECT_NAME}_SOURCE_DIR\\}")
+            message(
+              WARNING
+                "${CPM_INDENT} Patch file path '${singleOption}' does not contain \${${CPM_PROJECT_NAME}_SOURCE_DIR}, this may lead to issues when used as a dependency. Prepending \${PROJECT_SOURCE_DIR} to the path."
+            )
+            set(singleOption "${PROJECT_SOURCE_DIR}/${singleOption}")
+          endif()
+          string(REPLACE \$ "\\\$" singleOption ${singleOption})
+          string(REPLACE ${PROJECT_SOURCE_DIR} "\\\${${CPM_PROJECT_NAME}_SOURCE_DIR}" singleOption
+                         ${singleOption}
+          )
         endif()
         string(APPEND PRETTY_OUT_VAR "    \"${singleOption}\"\n")
       endforeach()

--- a/cmake/cpm_apply_patches.cmake
+++ b/cmake/cpm_apply_patches.cmake
@@ -1,0 +1,45 @@
+# Auto-generated patch application script
+separate_arguments(PATCH_FILES)
+
+foreach(patch_file IN LISTS PATCH_FILES)
+  message(STATUS "Checking patch: ${patch_file}")
+
+  execute_process(
+    COMMAND "${PATCH_EXECUTABLE}" --dry-run -p1
+    INPUT_FILE "${patch_file}"
+    RESULT_VARIABLE dry_run_result
+    OUTPUT_VARIABLE dry_out
+    ERROR_VARIABLE dry_err
+  )
+
+  if(dry_run_result EQUAL 0)
+    message(STATUS "Applying patch: ${patch_file}")
+    execute_process(
+      COMMAND "${PATCH_EXECUTABLE}" -p1
+      INPUT_FILE "${patch_file}"
+      RESULT_VARIABLE apply_result
+      OUTPUT_VARIABLE apply_out
+      ERROR_VARIABLE apply_err
+    )
+    if(apply_result EQUAL 0)
+      message(STATUS "Applied patch: ${patch_file}")
+    else()
+      message(FATAL_ERROR "Patch failed: ${patch_file}\n${apply_err}")
+    endif()
+  else()
+    execute_process(
+      COMMAND "${PATCH_EXECUTABLE}" --dry-run -p1 --reverse
+      INPUT_FILE "${patch_file}"
+      RESULT_VARIABLE reverse_result
+      OUTPUT_VARIABLE reverse_out
+      ERROR_VARIABLE reverse_err
+    )
+    if(reverse_result EQUAL 0)
+      message(STATUS "Patch already applied: ${patch_file}")
+    else()
+      message(
+        FATAL_ERROR "Patch cannot be applied and is not already applied: ${patch_file}\n${dry_err}"
+      )
+    endif()
+  endif()
+endforeach()


### PR DESCRIPTION
This pull-request is related to #618 and #664.

I've had several issues when trying to use CPM to apply a patch to a sub-dependency.
Every library uses package-lock files.

The dependency tree looks something like this:

```
Main project
└── Sub library
    └── External dependency that needs patching
    └── dependency.patch
```

When first trying this setup, I had the issue that the dependency.patch was applied multiple times, leading to the error described in #618. I've included the fix from #664 in this PR as it wont work without it.

The second issue was, that the sub library had a package lock file like this:
```
# sub-library
CPMDeclarePackage(sub-library
  GIT_TAG v1.0.0
  GIT_REPOSITORY xxx
  PATCHES
  "externals/dependency.patch"
)
```
So the patch file path was relative to the sub-library source dir.
However when running cpm-update-package-lock the file path was saved as an absolute path, which is not portable...
While fixing this, I noticed another problem:
the package-lock file of the main project gets the transient dependency and therefore also the PATCHES command from the sub-library, which is whats expected. However, now the CMake context is that of the main project, so we can't use any of the usual CMAKE_SOURCE_DIR variables etc in the path. This caused the patch file to not be found at all.
The only way I could think of to fix this was the following:

When running in the original sub-library context, the path is resolved (and found) and when no CMake variable is detected "${}", the current project source dir gets prepended to the path. This way the path is always relative to the actual target that contains the patch file.
I also fixed it, so that cpm-update-package-lock does not save the resolved absolute path but rather the unresolved path including all CMake variables before replacing them.

In the end this is the package-lock file which actually worked so far for me:

```
# sub-library
CPMDeclarePackage(sub-library
  GIT_TAG v1.0.0
  GIT_REPOSITORY xxx
  PATCHES
 "\${sub-library_SOURCE_DIR}/externals/dependency.patch"
)
```
Note: the CMake variable needs to be escaped, but this is done by CPM.
The user only needs to enter the relative path and when running cpm-update-package-lock it will preprend the SOURCE_DIR variable automatically.

