### PR TITLE
Support .tar.xz and .tar.zst in tarball URLs, fix #536

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -258,7 +258,7 @@ endfunction()
 
 # Try to infer package name and version from a url
 function(cpm_package_name_and_ver_from_url url outName outVer)
-  if(url MATCHES "[/\\?]([a-zA-Z0-9_\\.-]+)\\.(tar|tar\\.gz|tar\\.bz2|zip|ZIP)(\\?|/|$)")
+  if(url MATCHES "[/\\?]([a-zA-Z0-9_\\.-]+)\\.(tar|tar\\.gz|tar\\.bz2|tar\\.xz|tar\\.zst|zip|ZIP)(\\?|/|$)")
     # We matched an archive
     set(filename "${CMAKE_MATCH_1}")
 

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -258,7 +258,9 @@ endfunction()
 
 # Try to infer package name and version from a url
 function(cpm_package_name_and_ver_from_url url outName outVer)
-  if(url MATCHES "[/\\?]([a-zA-Z0-9_\\.-]+)\\.(tar|tar\\.gz|tar\\.bz2|tar\\.xz|tar\\.zst|zip|ZIP)(\\?|/|$)")
+  if(url MATCHES
+     "[/\\?]([a-zA-Z0-9_\\.-]+)\\.(tar|tar\\.gz|tar\\.bz2|tar\\.xz|tar\\.zst|zip|ZIP)(\\?|/|$)"
+  )
     # We matched an archive
     set(filename "${CMAKE_MATCH_1}")
 

--- a/test/unit/package_name_and_ver_from_url.cmake
+++ b/test/unit/package_name_and_ver_from_url.cmake
@@ -55,6 +55,12 @@ cpm_package_name_and_ver_from_url("https://example.com/foo" name ver)
 assert_not_defined(name)
 assert_not_defined(ver)
 
+cpm_package_name_and_ver_from_url(
+  "http://downloads.xiph.org/releases/ogg/libogg-1.3.5.tar.xz" name ver
+)
+assert_equal("libogg" ${name})
+assert_equal("1.3.5" ${ver})
+
 cpm_package_name_and_ver_from_url("example.zip.com/foo" name ver)
 assert_not_defined(name)
 assert_not_defined(ver)


### PR DESCRIPTION
see issue #536