### PR TITLE
Add notes on supply chain security to the project readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ CPMAddPackage("https://example.com/my-package-1.2.3.zip#MD5=68e20f674a48be38d60e
 CPMAddPackage("https://example.com/my-package.zip@1.2.3")
 ```
 
+> **Supply chain security best practice:**
+> For maximum security and reproducibility, always prefer specifying immutable git commit hashes instead of tags or branches when referencing dependencies. Tags and branches can be changed or moved, but commit hashes always refer to the same code. You can specify a commit hash before the version in the URI, e.g. `gh:user/repo#<commit>@<version>`. This ensures your builds are protected from unexpected upstream changes or attacks.
+
 Additionally, if needed, extra arguments can be provided while using single argument syntax by using the shorthand syntax with the `URI` specifier.
 
 ```cmake
@@ -537,7 +540,10 @@ CPMAddPackage(
 )
 ```
 
-URL_HASH is optional, but it's a good idea for releases.
+`URL_HASH` is optional, but it's a good idea for releases.
+
+> **Supply chain security best practice:**
+> When using source archives, always specify a hash (e.g., `SHA256`) with the `URL_HASH` option. This ensures the downloaded archive matches the expected content and helps prevent supply chain attacks. Never rely solely on URLs or tags for security.
 
 
 ### Identifying the URL


### PR DESCRIPTION
This pull request improves the documentation in the `README.md` file by adding important supply chain security best practices for handling dependencies. The new guidance helps users ensure their builds are more secure and reproducible by recommending the use of commit hashes and hash verification for source archives.

Supply chain security best practices:

* Added a recommendation to always prefer specifying immutable git commit hashes instead of tags or branches when referencing dependencies, to ensure reproducibility and protection from upstream changes.
* Added advice to always specify a hash (such as `SHA256`) with the `URL_HASH` option when using source archives, to verify the integrity of downloaded files and prevent supply chain attacks.