### PR TITLE
Clarify DOWNLOAD_ONLY option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ CPMAddPackage(
   VERSION       # The minimum version of the dependency (optional, defaults to 0)
   PATCHES       # Patch files to be applied sequentially using patch and PATCH_OPTIONS (optional)
   OPTIONS       # Configuration options passed to the dependency (optional)
-  DOWNLOAD_ONLY # If set, the project is downloaded, but not configured (optional)
+  DOWNLOAD_ONLY # If set to YES, the project is downloaded, but not configured (optional, default NO)
   [...]         # Origin parameters forwarded to FetchContent_Declare, see below
 )
 ```


### PR DESCRIPTION
Documentation wording suggests that DOWNLOAD_ONLY is a flag, whose presence is sufficient to disable project configuration. In fact DOWNLOAD_ONLY is an option taking one argument.