### PR TITLE
Add GENERATED package lock mode (pnpm/npm style, commit-pinned)

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,31 @@ cmake -Bbuild
 cmake --build build --target cpm-update-package-lock
 ```
 
+### Generated package lock (pnpm/npm style)
+
+Pass `GENERATED` to keep the lock in sync automatically, the way `pnpm-lock.yaml` or
+`package-lock.json` work:
+
+```cmake
+CPMUsePackageLock(package-lock.cmake GENERATED)
+```
+
+In this mode the lock at the given path is rewritten in your source tree on **every configure**,
+and git packages are pinned to the **exact commit that was checked out** rather than the (possibly
+moving) `GIT_TAG`. This makes the lock reproducible even when dependencies are declared against a
+branch like `main`. No separate `cpm-update-package-lock` step is needed.
+
+To refresh the pins (e.g. to pull in newer upstream commits), delete the lock file and reconfigure,
+just like deleting a `pnpm-lock.yaml`:
+
+```bash
+rm package-lock.cmake
+cmake -Bbuild
+```
+
+The same behaviour can be enabled globally without editing `CMakeLists.txt` by setting the
+`CPM_GENERATE_PACKAGE_LOCK` option (or environment variable).
+
 See the [wiki](https://github.com/cpm-cmake/CPM.cmake/wiki/Package-lock) for more info.
 
 ## Private repositories and CI

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -129,6 +129,11 @@ option(CPM_INCLUDE_ALL_IN_PACKAGE_LOCK
        "Add all packages added through CPM.cmake to the package lock"
        $ENV{CPM_INCLUDE_ALL_IN_PACKAGE_LOCK}
 )
+option(
+  CPM_GENERATE_PACKAGE_LOCK
+  "Keep the package lock in sync on every configure (pnpm/npm style), pinning git deps to the resolved commit"
+  $ENV{CPM_GENERATE_PACKAGE_LOCK}
+)
 option(CPM_USE_NAMED_CACHE_DIRECTORIES
        "Use additional directory of package name in cache on the most nested level."
        $ENV{CPM_USE_NAMED_CACHE_DIRECTORIES}
@@ -945,16 +950,6 @@ function(CPMAddPackage)
     cpm_create_module_file(${CPM_ARGS_NAME} "CPMAddPackage(\"${ARGN}\")")
   endif()
 
-  if(CPM_PACKAGE_LOCK_ENABLED)
-    if((CPM_ARGS_VERSION AND NOT CPM_ARGS_SOURCE_DIR) OR CPM_INCLUDE_ALL_IN_PACKAGE_LOCK)
-      cpm_add_to_package_lock(${CPM_ARGS_NAME} "${ARGN}")
-    elseif(CPM_ARGS_SOURCE_DIR)
-      cpm_add_comment_to_package_lock(${CPM_ARGS_NAME} "local directory")
-    else()
-      cpm_add_comment_to_package_lock(${CPM_ARGS_NAME} "${ARGN}")
-    endif()
-  endif()
-
   cpm_message(
     STATUS "${CPM_INDENT} Adding package ${CPM_ARGS_NAME}@${CPM_ARGS_VERSION} (${PACKAGE_INFO})"
   )
@@ -1006,6 +1001,41 @@ function(CPMAddPackage)
     cpm_get_fetch_properties("${CPM_ARGS_NAME}")
   endif()
 
+  # Record the package in the lock. This runs after the fetch so a generated lock can pin git
+  # packages to the commit that was actually checked out (the source dir now exists).
+  if(CPM_PACKAGE_LOCK_ENABLED)
+    set(CPM_LOCK_ARGN "${ARGN}")
+    if(CPM_PACKAGE_LOCK_GENERATED
+       AND DEFINED CPM_ARGS_GIT_REPOSITORY
+       AND DEFINED ${CPM_ARGS_NAME}_SOURCE_DIR
+    )
+      cpm_get_git_commit_hash("${${CPM_ARGS_NAME}_SOURCE_DIR}" CPM_LOCK_COMMIT)
+      if(CPM_LOCK_COMMIT)
+        # Replace the (possibly moving) GIT_TAG with the resolved commit, so the lock is
+        # reproducible regardless of where the branch/tag later points.
+        list(FIND CPM_LOCK_ARGN "GIT_TAG" CPM_LOCK_GIT_TAG_INDEX)
+        if(CPM_LOCK_GIT_TAG_INDEX GREATER -1)
+          math(EXPR CPM_LOCK_GIT_TAG_VALUE_INDEX "${CPM_LOCK_GIT_TAG_INDEX} + 1")
+          list(REMOVE_AT CPM_LOCK_ARGN ${CPM_LOCK_GIT_TAG_VALUE_INDEX})
+          list(INSERT CPM_LOCK_ARGN ${CPM_LOCK_GIT_TAG_VALUE_INDEX} "${CPM_LOCK_COMMIT}")
+        else()
+          list(APPEND CPM_LOCK_ARGN GIT_TAG "${CPM_LOCK_COMMIT}")
+        endif()
+      endif()
+    endif()
+
+    if((CPM_ARGS_VERSION AND NOT CPM_ARGS_SOURCE_DIR)
+       OR CPM_INCLUDE_ALL_IN_PACKAGE_LOCK
+       OR (CPM_PACKAGE_LOCK_GENERATED AND NOT CPM_ARGS_SOURCE_DIR)
+    )
+      cpm_add_to_package_lock(${CPM_ARGS_NAME} "${CPM_LOCK_ARGN}")
+    elseif(CPM_ARGS_SOURCE_DIR)
+      cpm_add_comment_to_package_lock(${CPM_ARGS_NAME} "local directory")
+    else()
+      cpm_add_comment_to_package_lock(${CPM_ARGS_NAME} "${ARGN}")
+    endif()
+  endif()
+
   set(${CPM_ARGS_NAME}_ADDED YES)
   cpm_export_variables("${CPM_ARGS_NAME}")
 endfunction()
@@ -1047,6 +1077,35 @@ macro(CPMDeclarePackage Name)
   endif()
 endmacro()
 
+# Resolves the exact commit currently checked out in a git package's source dir, so a generated
+# package lock can pin it. Sets ${result} to the empty string when it cannot be determined.
+function(cpm_get_git_commit_hash repoPath result)
+  set(${result}
+      ""
+      PARENT_SCOPE
+  )
+
+  find_package(Git QUIET)
+  if(NOT GIT_EXECUTABLE OR NOT EXISTS "${repoPath}/.git")
+    return()
+  endif()
+
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+    WORKING_DIRECTORY ${repoPath}
+    RESULT_VARIABLE resultGitRevParse
+    OUTPUT_VARIABLE commitHash
+    OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET
+  )
+
+  if(resultGitRevParse EQUAL 0)
+    set(${result}
+        "${commitHash}"
+        PARENT_SCOPE
+    )
+  endif()
+endfunction()
+
 function(cpm_add_to_package_lock Name)
   if(NOT CPM_DONT_CREATE_PACKAGE_LOCK)
     cpm_prettify_package_arguments(PRETTY_ARGN false ${ARGN})
@@ -1063,19 +1122,49 @@ function(cpm_add_comment_to_package_lock Name)
   endif()
 endfunction()
 
-# includes the package lock file if it exists and creates a target `cpm-update-package-lock` to
-# update it
+# Includes the package lock file if it exists and creates a target `cpm-update-package-lock` to
+# update it.
+#
+# Pass GENERATED (or set CPM_GENERATE_PACKAGE_LOCK) for pnpm/npm-style behaviour: the lock at <file>
+# is (re)written in the source tree on every configure and git packages are pinned to the exact
+# commit that was checked out, so it stays in sync with no separate update step. Delete the file and
+# reconfigure to refresh the pins, just like deleting a `pnpm-lock.yaml`.
 macro(CPMUsePackageLock file)
   if(NOT CPM_DONT_CREATE_PACKAGE_LOCK)
+    cmake_parse_arguments(CPM_USE_LOCK "GENERATED" "" "" ${ARGN})
+
     get_filename_component(CPM_ABSOLUTE_PACKAGE_LOCK_PATH ${file} ABSOLUTE)
+
+    # Apply any existing pins before the lock is (re)written below.
     if(EXISTS ${CPM_ABSOLUTE_PACKAGE_LOCK_PATH})
       include(${CPM_ABSOLUTE_PACKAGE_LOCK_PATH})
     endif()
-    if(NOT TARGET cpm-update-package-lock)
-      add_custom_target(
-        cpm-update-package-lock COMMAND ${CMAKE_COMMAND} -E copy ${CPM_PACKAGE_LOCK_FILE}
-                                        ${CPM_ABSOLUTE_PACKAGE_LOCK_PATH}
+
+    if(CPM_USE_LOCK_GENERATED OR CPM_GENERATE_PACKAGE_LOCK)
+      # Author the lock directly in the source tree and keep it current on every configure.
+      set(CPM_PACKAGE_LOCK_GENERATED
+          TRUE
+          CACHE INTERNAL ""
       )
+      set(CPM_PACKAGE_LOCK_FILE
+          "${CPM_ABSOLUTE_PACKAGE_LOCK_PATH}"
+          CACHE INTERNAL ""
+      )
+      file(
+        WRITE ${CPM_PACKAGE_LOCK_FILE}
+        "# CPM Package Lock\n# This file is generated by CPM.cmake and should be committed to version control\n\n"
+      )
+    else()
+      set(CPM_PACKAGE_LOCK_GENERATED
+          FALSE
+          CACHE INTERNAL ""
+      )
+      if(NOT TARGET cpm-update-package-lock)
+        add_custom_target(
+          cpm-update-package-lock COMMAND ${CMAKE_COMMAND} -E copy ${CPM_PACKAGE_LOCK_FILE}
+                                          ${CPM_ABSOLUTE_PACKAGE_LOCK_PATH}
+        )
+      endif()
     endif()
     set(CPM_PACKAGE_LOCK_ENABLED true)
   endif()

--- a/test/unit/package-lock-generated.cmake
+++ b/test/unit/package-lock-generated.cmake
@@ -1,0 +1,90 @@
+include(${CPM_PATH}/testing.cmake)
+
+# Exercises `CPMUsePackageLock(<file> GENERATED)`: the lock must be written into the source tree on
+# configure (no cpm-update-package-lock step) with git packages pinned to the resolved commit. Uses
+# a throwaway local git repo so the test is hermetic (no network).
+
+find_package(Git REQUIRED)
+
+set(SCRATCH ${CMAKE_CURRENT_BINARY_DIR}/package-lock-generated)
+set(REPO ${SCRATCH}/dep-repo)
+set(PROJECT_DIR ${SCRATCH}/project)
+set(BUILD_DIR ${SCRATCH}/build)
+set(LOCK ${PROJECT_DIR}/package-lock.cmake)
+
+execute_process(COMMAND ${CMAKE_COMMAND} -E rm -rf ${SCRATCH})
+file(MAKE_DIRECTORY ${REPO})
+
+# ---- create a dependency git repo with a single commit on branch `testbranch` ----
+file(WRITE ${REPO}/VERSION "1.0")
+
+function(git)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} ${ARGN}
+    WORKING_DIRECTORY ${REPO}
+    RESULT_VARIABLE git_result
+    OUTPUT_QUIET ERROR_QUIET
+  )
+  assert_equal(${git_result} "0")
+endfunction()
+
+git(init)
+git(config user.email "test@example.com")
+git(config user.name "CPM Test")
+git(add -A)
+git(commit -m "initial commit")
+git(branch -M testbranch)
+
+execute_process(
+  COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+  WORKING_DIRECTORY ${REPO}
+  OUTPUT_VARIABLE EXPECTED_SHA
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# ---- a project that locks the dependency in GENERATED mode, declared against the branch ----
+file(MAKE_DIRECTORY ${PROJECT_DIR})
+file(
+  WRITE ${PROJECT_DIR}/CMakeLists.txt
+  "cmake_minimum_required(VERSION 3.14)
+project(GeneratedLockTest NONE)
+include(${CPM_PATH}/CPM.cmake)
+CPMUsePackageLock(package-lock.cmake GENERATED)
+CPMAddPackage(
+  NAME Dep
+  GIT_REPOSITORY ${REPO}
+  GIT_TAG testbranch
+  DOWNLOAD_ONLY YES
+)
+"
+)
+
+# Configure only — no `cpm-update-package-lock` target is built.
+execute_process(COMMAND ${CMAKE_COMMAND} -S ${PROJECT_DIR} -B ${BUILD_DIR} RESULT_VARIABLE ret)
+assert_equal(${ret} "0")
+
+# The lock must have been authored into the source tree automatically.
+assert_exists(${LOCK})
+
+file(READ ${LOCK} LOCK_RUN1)
+
+string(FIND "${LOCK_RUN1}" "${EXPECTED_SHA}" sha_pos)
+if(sha_pos EQUAL -1)
+  assertion_failed(
+    "generated lock did not pin Dep to the resolved commit ${EXPECTED_SHA}:\n${LOCK_RUN1}"
+  )
+endif()
+message(STATUS "test passed: generated lock pinned Dep to ${EXPECTED_SHA}")
+
+string(FIND "${LOCK_RUN1}" "GIT_TAG testbranch" branch_pos)
+if(NOT branch_pos EQUAL -1)
+  assertion_failed("generated lock still references the moving branch instead of a commit")
+endif()
+message(STATUS "test passed: generated lock does not reference the moving branch")
+
+# Reconfiguring must be idempotent: the pin is consumed and an identical lock is produced.
+execute_process(COMMAND ${CMAKE_COMMAND} -S ${PROJECT_DIR} -B ${BUILD_DIR} RESULT_VARIABLE ret2)
+assert_equal(${ret2} "0")
+file(READ ${LOCK} LOCK_RUN2)
+assert_equal("${LOCK_RUN1}" "${LOCK_RUN2}")
+message(STATUS "test passed: generated lock is stable across reconfigures")


### PR DESCRIPTION
## Motivation

The current package lock records each dependency's declaration **verbatim** and only updates when you build the `cpm-update-package-lock` target. For projects that declare deps against a moving ref (e.g. `GIT_TAG main`), this has two rough edges compared to `pnpm-lock.yaml` / `package-lock.json`:

1. The lock isn't reproducible — it records `GIT_TAG main`, not the commit that was actually used.
2. It doesn't regenerate on its own. Delete it and reconfigure and it stays gone until you remember the separate target step.

## What this adds

A `GENERATED` keyword on `CPMUsePackageLock` (and an equivalent `CPM_GENERATE_PACKAGE_LOCK` option / env var):

```cmake
CPMUsePackageLock(package-lock.cmake GENERATED)
```

In this mode:

- **Auto-maintained**: the lock at the given path is rewritten in the source tree on every configure — no `cpm-update-package-lock` step. Delete it and reconfigure to refresh the pins, just like deleting a pnpm lock.
- **Commit-pinned**: git packages are pinned to the exact commit that was checked out, not the declared (possibly moving) `GIT_TAG`. The pin is then consumed on the next configure (declarations override call-site args), so it's stable/idempotent: `main` → resolved commit on the first run, identical lock thereafter.

Existing (non-`GENERATED`) behaviour is unchanged.

## Implementation notes

- The lock entry is now written **after** the fetch instead of before it, so the package source dir exists and its commit can be resolved. This is the only behavioural move for the existing path; the same set of packages is recorded as before.
- New helper `cpm_get_git_commit_hash()` reads the checked-out `HEAD` (falls back gracefully — no git / not a repo / URL packages → unchanged args).
- `CPMUsePackageLock` now `cmake_parse_arguments` for the `GENERATED` flag, includes any existing lock first (to apply current pins), then redirects `CPM_PACKAGE_LOCK_FILE` at the source path and rewrites it.

## Tests

Adds `test/unit/package-lock-generated.cmake` — hermetic (spins up a throwaway local git repo, **no network**) — asserting that after a plain configure (no target build) the lock is written into the source tree, pins the dependency to the resolved commit (and no longer references the branch), and is byte-identical across a reconfigure.

Formatted with the repo's `cmake-format` 0.6.11 config; existing package-lock unit tests still pass.